### PR TITLE
Build script improvements and more debugging for remote connections.

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK.xcodeproj/project.pbxproj
+++ b/AlfrescoSDK/AlfrescoSDK.xcodeproj/project.pbxproj
@@ -1444,7 +1444,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_AFTER_BUILD = YES;
+				TEST_AFTER_BUILD = NO;
 			};
 			name = Debug;
 		};
@@ -1467,7 +1467,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_AFTER_BUILD = YES;
+				TEST_AFTER_BUILD = NO;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1492,7 +1492,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = /AlfrescoSDK;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_AFTER_BUILD = YES;
+				TEST_AFTER_BUILD = NO;
 			};
 			name = Debug;
 		};
@@ -1516,7 +1516,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = /AlfrescoSDK;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_AFTER_BUILD = YES;
+				TEST_AFTER_BUILD = NO;
 			};
 			name = Release;
 		};
@@ -1531,7 +1531,7 @@
 				GCC_PREFIX_HEADER = "AlfrescoSDK/AlfrescoSDK-Prefix.pch";
 				INFOPLIST_FILE = "AlfrescoSDKTests/AlfrescoSDKTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_AFTER_BUILD = YES;
+				TEST_AFTER_BUILD = NO;
 				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
@@ -1547,7 +1547,7 @@
 				GCC_PREFIX_HEADER = "AlfrescoSDK/AlfrescoSDK-Prefix.pch";
 				INFOPLIST_FILE = "AlfrescoSDKTests/AlfrescoSDKTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_AFTER_BUILD = YES;
+				TEST_AFTER_BUILD = NO;
 				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoDefaultHTTPRequest.m
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoDefaultHTTPRequest.m
@@ -54,7 +54,10 @@
     [urlRequest setHTTPMethod:method];
     
     [headers enumerateKeysAndObjectsUsingBlock:^(NSString *headerKey, NSString *headerValue, BOOL *stop){
-        AlfrescoLogDebug(@"headerKey = %@, headerValue = %@", headerKey, headerValue);
+        if ([AlfrescoLog sharedInstance].logLevel == AlfrescoLogLevelTrace)
+        {
+            AlfrescoLogTrace(@"headerKey = %@, headerValue = %@", headerKey, headerValue);
+        }
         [urlRequest addValue:headerValue forHTTPHeaderField:headerKey];
     }];
     
@@ -76,6 +79,11 @@
     {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         self.statusCode = httpResponse.statusCode;
+        
+        if ([AlfrescoLog sharedInstance].logLevel == AlfrescoLogLevelTrace)
+        {
+            AlfrescoLogTrace(@"response status code: %d", self.statusCode);
+        }
     }
     else
     {
@@ -107,8 +115,7 @@
         error = [AlfrescoErrors alfrescoErrorWithAlfrescoErrorCode:kAlfrescoErrorCodeHTTPResponse];
     }
     
-    AlfrescoLog *logger = [AlfrescoLog sharedInstance];
-    if (logger.logLevel == AlfrescoLogLevelTrace)
+    if ([AlfrescoLog sharedInstance].logLevel == AlfrescoLogLevelTrace)
     {
         AlfrescoLogTrace(@"response body: %@", [[NSString alloc] initWithData:self.responseData encoding:NSUTF8StringEncoding]);
     }
@@ -125,6 +132,8 @@
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
 {
+    [[AlfrescoLog sharedInstance] logErrorFromError:error];
+    
     if (self.completionBlock != NULL)
     {
         self.completionBlock(nil, error);

--- a/AlfrescoSDK/build_appledoc.sh
+++ b/AlfrescoSDK/build_appledoc.sh
@@ -1,9 +1,16 @@
-rm -rf AlfrescoSDKHelp
+#!/bin/bash
+
+# remove previous generated documentation
+if [ -d AlfrescoSDKHelp ]; then
+  rm -R AlfrescoSDKHelp
+fi
+
+# create directory
 mkdir AlfrescoSDKHelp
 
 # Build documentation if appledoc is installed
 if type -p appledoc &>/dev/null; then
-    appledoc --project-name AlfrescoSDK --project-company "Alfresco" --company-id com.alfresco.alfrescosdk --output AlfrescoSDKHelp --keep-intermediate-files --exit-threshold 2 --ignore .m --ignore AlfrescoSDKTests . --ignore CMIS .
+    appledoc --project-name AlfrescoSDK --project-company "Alfresco" --company-id com.alfresco --output AlfrescoSDKHelp --keep-intermediate-files --exit-threshold 2 --ignore .m --ignore AlfrescoSDKTests . --ignore CMIS .
 else
     echo "appledoc executable can not be found, you can find installation instuctions at https://github.com/tomaz/appledoc"
 fi

--- a/AlfrescoSDK/build_universal_lib.sh
+++ b/AlfrescoSDK/build_universal_lib.sh
@@ -1,3 +1,15 @@
+#!/bin/bash
+
+# ensure the universal library is built
 BUILD_UNIVERSAL_LIB='TRUE'
 export BUILD_UNIVERSAL_LIB
-xcodebuild -project AlfrescoSDK.xcodeproj -target AlfrescoSDK -configuration Debug clean build
+
+if [[ "$1" == "Debug" ]] ; then
+   BUILD_CONFIG=Debug
+   echo "Building debug version of universal library..."
+else
+   BUILD_CONFIG=Release
+   echo "Building release version of universal library..."
+fi
+
+xcodebuild -project AlfrescoSDK.xcodeproj -target AlfrescoSDK -configuration $BUILD_CONFIG clean build

--- a/AlfrescoSDK/run_test.sh
+++ b/AlfrescoSDK/run_test.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
 # remove previous test reports
-if [ -d test-reports ]
-then
+if [ -d test-reports ]; then
   echo "Removing previous test-reports folder..."
   rm -R test-reports
 fi
 
 # define the main command
-# TODO: Find a way to override the project TEST_AFTER_BUILD setting and set to YES
-BUILD_CMD="xcodebuild -sdk iphonesimulator -project AlfrescoSDK.xcodeproj -target AlfrescoSDKTests -configuration Debug build"
+BUILD_CMD="xcodebuild -sdk iphonesimulator -project AlfrescoSDK.xcodeproj -target AlfrescoSDKTests -configuration Debug TEST_AFTER_BUILD=YES build"
 
 # determine whether to pipe the unit tests results or not
 if [[ "$1" == "-output-junit-results" ]] ; then


### PR DESCRIPTION
build_universal_lib.sh now takes a parameter, if it is Debug, a debug static library gets built otherwise a release static library is created.

run_test.sh now sets the TEST_AFTER_BUILD flag to YES which means it can be set to NO permanently for developers.

The HTTP status code is now output if logging is set to Trace and any connection errors are now logged.
