### PR TITLE
MOBSDK-625: SDK gives wrong error code if Cloud Access Token is expired

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoErrors.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoErrors.m
@@ -128,6 +128,10 @@ NSString * const kAlfrescoErrorDescriptionWorkflowNoTaskFound = @"Workflow Task 
             {
                 code = isExpired ? kAlfrescoErrorCodeRefreshTokenExpired : kAlfrescoErrorCodeRefreshTokenInvalid;
             }
+            else if ([descriptionObj hasPrefix:@"The access token"])
+            {
+                code = kAlfrescoErrorCodeAccessTokenExpired;
+            }
             else
             {
                 code = kAlfrescoErrorCodeInvalidRequest;

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoDefaultHTTPRequest.m
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoDefaultHTTPRequest.m
@@ -146,7 +146,18 @@
     {
         if (self.statusCode == 401)
         {
-            error = [AlfrescoErrors alfrescoErrorWithAlfrescoErrorCode:kAlfrescoErrorCodeUnauthorisedAccess];
+            NSError *jsonError = nil;
+            id jsonDictionary = [NSJSONSerialization JSONObjectWithData:self.responseData options:0 error:&jsonError];
+            NSError *errorFromDescription = [AlfrescoErrors alfrescoErrorFromJSONParameters:jsonDictionary];
+            
+            if (!jsonError && errorFromDescription.code != kAlfrescoErrorCodeJSONParsing)
+            {
+                error = errorFromDescription;
+            }
+            else
+            {
+                error = [AlfrescoErrors alfrescoErrorWithAlfrescoErrorCode:kAlfrescoErrorCodeUnauthorisedAccess];
+            }
         }
         else
         {


### PR DESCRIPTION
The string @"The access token" is hard coded, because other prefixes are currently hard coded as well, so did the same to be consistent. Maybe needs refactoring to use constants.
