### PR TITLE
MOBSDK-654: Member related methods now follow SDK naming conventions

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Services/AlfrescoSiteService.h
+++ b/AlfrescoSDK/AlfrescoSDK/Services/AlfrescoSiteService.h
@@ -171,34 +171,37 @@
  @param site - site from which members are retrieved
  @param completionBlock - contains Array of person objects who are member of site if successful, or nil if not.
  */
-- (AlfrescoRequest *)retrieveAllMembers:(AlfrescoSite *)site completionBlock:(AlfrescoArrayCompletionBlock)completionBlock;
+- (AlfrescoRequest *)retrieveAllMembersOfSite:(AlfrescoSite *)site
+                              completionBlock:(AlfrescoArrayCompletionBlock)completionBlock;
 
-/** Returns a paged list of all members for a site.
+/** Returns a paged list of site members.
  @param site - site from which members are retrieved
  @param listingContext - The listing context with a paging definition that's used to retrieve members.
  @param completionBlock - contains Array of person objects that are members of the site if successful, or nil if not.
  */
-- (AlfrescoRequest *)retrieveAllMembers:(AlfrescoSite *)site
-                     WithListingContext:(AlfrescoListingContext *)listingContext
-                        completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock;
+- (AlfrescoRequest *)retrieveMembersOfSite:(AlfrescoSite *)site
+                            listingContext:(AlfrescoListingContext *)listingContext
+                           completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock;
 
-/** Returns a paged list of all members for a site that respect the filter.
+/** Returns a paged list of site members that respect the filter.
  @param site - site from which members are retrieved
- @param filter - filter that needs to be applied to search query.
+ @param usingFilter - filter that needs to be applied to search query.
  @param listingContext - The listing context with a paging definition that's used to retrieve members.
  @param completionBlock - contains Array of person objects that are members of the site if successful, or nil if not.
  */
-- (AlfrescoRequest *)searchMembers:(AlfrescoSite *)site
-                            filter:(NSString *)filter
-                WithListingContext:(AlfrescoListingContext *)listingContext
-                   completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock;
+- (AlfrescoRequest *)searchMembersOfSite:(AlfrescoSite *)site
+                             usingFilter:(NSString *)filter
+                          listingContext:(AlfrescoListingContext *)listingContext
+                         completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock;
 
 /** Returns true if the person is member of the site, returns false otherwise
  @param person - person for whome membership status is retrieved
  @param site - site from which membership status for the person is retrieved
  @param completionBlock - returns yes or no depending of person membership status in the site
  */
-- (AlfrescoRequest *)isPerson:(AlfrescoPerson *)person memberOfSite:(AlfrescoSite *)site completionBlock:(AlfrescoMemberCompletionBlock)completionBlock;
+- (AlfrescoRequest *)isPerson:(AlfrescoPerson *)person
+                 memberOfSite:(AlfrescoSite *)site
+              completionBlock:(AlfrescoMemberCompletionBlock)completionBlock;
 
 /**
  clears the sites cache

--- a/AlfrescoSDK/AlfrescoSDK/Services/AlfrescoSiteService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/AlfrescoSiteService.m
@@ -140,30 +140,33 @@
     return nil;    
 }
 
-- (AlfrescoRequest *)retrieveAllMembers:(AlfrescoSite *)site completionBlock:(AlfrescoArrayCompletionBlock)completionBlock
+- (AlfrescoRequest *)retrieveAllMembersOfSite:(AlfrescoSite *)site
+                              completionBlock:(AlfrescoArrayCompletionBlock)completionBlock
 {
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }
 
-- (AlfrescoRequest *)retrieveAllMembers:(AlfrescoSite *)site
-                     WithListingContext:(AlfrescoListingContext *)listingContext
-                        completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
+- (AlfrescoRequest *)retrieveMembersOfSite:(AlfrescoSite *)site
+                            listingContext:(AlfrescoListingContext *)listingContext
+                           completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }
 
-- (AlfrescoRequest *)searchMembers:(AlfrescoSite *)site
-                            filter:(NSString *)filter
-                WithListingContext:(AlfrescoListingContext *)listingContext
-                   completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
+- (AlfrescoRequest *)searchMembersOfSite:(AlfrescoSite *)site
+                             usingFilter:(NSString *)filter
+                          listingContext:(AlfrescoListingContext *)listingContext
+                         completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }
 
-- (AlfrescoRequest *)isPerson:(AlfrescoPerson *)person memberOfSite:(AlfrescoSite *)site completionBlock:(AlfrescoMemberCompletionBlock)completionBlock
+- (AlfrescoRequest *)isPerson:(AlfrescoPerson *)person
+                 memberOfSite:(AlfrescoSite *)site
+              completionBlock:(AlfrescoMemberCompletionBlock)completionBlock
 {
     [self doesNotRecognizeSelector:_cmd];
     return nil;


### PR DESCRIPTION
Renamed methods, enhanced tests and fixed a couple of bugs in the Cloud site service (it was using on premise URL arguments and not filtering returned users).
