### PR TITLE
MOBSDK-683

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.h
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.h
@@ -80,7 +80,7 @@ extern NSString * const kAlfrescoMetadataExtraction;
 extern NSString * const kAlfrescoThumbnailCreation;
 
 /**---------------------------------------------------------------------------------------
- * @name thumbnail constant (for OnPremise services)
+ * @name thumbnail constant
  --------------------------------------------------------------------------------------- */
 extern NSString * const kAlfrescoThumbnailRendition;
 
@@ -127,6 +127,23 @@ extern NSString * const kAlfrescoConnectUsingClientSSLCertificate;
 extern NSString * const kAlfrescoClientCertificateCredentials;
 
 /**---------------------------------------------------------------------------------------
+ * @name Model Constants
+ --------------------------------------------------------------------------------------- */
+extern NSString * const kAlfrescoContentModelTypeContent;
+extern NSString * const kAlfrescoContentModelTypeFolder;
+
+extern NSString * const kAlfrescoContentModelAspectTitled;
+extern NSString * const kAlfrescoContentModelAspectAuthor;
+extern NSString * const kAlfrescoContentModelAspectGeographic;
+
+extern NSString * const kAlfrescoContentModelPropertyName;
+extern NSString * const kAlfrescoContentModelPropertyTitle;
+extern NSString * const kAlfrescoContentModelPropertyDescription;
+extern NSString * const kAlfrescoContentModelPropertyAuthor;
+extern NSString * const kAlfrescoContentModelPropertyLatitude;
+extern NSString * const kAlfrescoContentModelPropertyLongitude;
+
+/**---------------------------------------------------------------------------------------
  * @name Workflow Constants
  --------------------------------------------------------------------------------------- */
 extern NSString * const kAlfrescoWorkflowTaskComment;
@@ -140,3 +157,9 @@ extern NSString * const kAlfrescoWorkflowProcessPriority;
 extern NSString * const kAlfrescoWorkflowProcessSendEmailNotification;
 extern NSString * const kAlfrescoWorkflowProcessDueDate;
 extern NSString * const kAlfrescoWorkflowProcessApprovalRate;
+
+
+
+
+
+

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.m
@@ -81,6 +81,23 @@ NSString * const kAlfrescoNetworkProvider = @"org.alfresco.mobile.session.networ
 NSString * const kAlfrescoCMISBindingURL = @"org.alfresco.mobile.session.cmisbindingurl";
 
 /**
+ Model Constants
+ */
+NSString * const kAlfrescoContentModelTypeContent = @"cm:content";
+NSString * const kAlfrescoContentModelTypeFolder = @"cm:folder";
+
+NSString * const kAlfrescoContentModelAspectTitled = @"cm:titled";
+NSString * const kAlfrescoContentModelAspectAuthor = @"cm:author";
+NSString * const kAlfrescoContentModelAspectGeographic = @"cm:geographic";
+
+NSString * const kAlfrescoContentModelPropertyName = @"cm:name";
+NSString * const kAlfrescoContentModelPropertyTitle = @"cm:title";
+NSString * const kAlfrescoContentModelPropertyDescription = @"cm:description";
+NSString * const kAlfrescoContentModelPropertyAuthor = @"cm:author";
+NSString * const kAlfrescoContentModelPropertyLatitude = @"cm:latitude";
+NSString * const kAlfrescoContentModelPropertyLongitude = @"cm:longitude";
+
+/**
  Workflow Task Constants
  */
 NSString * const kAlfrescoWorkflowTaskComment = @"org.alfresco.mobile.task.comment";

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.h
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.h
@@ -24,18 +24,21 @@
 extern NSString * const kAlfrescoClassVersion;
 
 extern NSString * const kAlfrescoISO8601DateStringFormat;
+
 extern NSString * const kAlfrescoCMISPropertyTypeInt;
 extern NSString * const kAlfrescoCMISPropertyTypeBoolean;
 extern NSString * const kAlfrescoCMISPropertyTypeDatetime;
 extern NSString * const kAlfrescoCMISPropertyTypeDecimal;
 extern NSString * const kAlfrescoCMISPropertyTypeId;
-extern NSString * const kAlfrescoCMISSessionMode;
+extern NSString * const kAlfrescoCMISNetworkProvider;
+extern NSString * const kAlfrescoCMISModelPrefix;
+extern NSString * const kAlfrescoCMISFolderTypePrefix;
+extern NSString * const kAlfrescoCMISDocumentTypePrefix;
+extern NSString * const kAlfrescoCMISAspectPrefix;
 
-extern NSString * const kAlfrescoPropertyName;
-extern NSString * const kAlfrescoPropertyTitle;
-extern NSString * const kAlfrescoPropertyDescription;
-extern NSString * const kAlfrescoTypeContent;
-extern NSString * const kAlfrescoTypeFolder;
+extern NSString * const kAlfrescoContentModelPrefix;
+extern NSString * const kAlfrescoSystemModelPrefix;
+extern NSString * const kAlfrescoSystemModelAspectLocalized;
 
 extern NSString * const kAlfrescoRepositoryName;
 extern NSString * const kAlfrescoRepositoryEdition;
@@ -339,10 +342,6 @@ extern NSString * const kAlfrescoHTTPPOST;
 extern NSString * const kAlfrescoHTTPPut;
 
 extern NSString * const kAlfrescoFileManagerClass;
-extern NSString * const kAlfrescoCMISNetworkProvider;
-extern NSString * const kAlfrescoPropertyTypeFolder;
-extern NSString * const kAlfrescoPropertyTypeDocument;
-extern NSString * const kAlfrescoPropertyAspect;
 
 extern NSString * const kAlfrescoPersonPropertyFirstName;
 extern NSString * const kAlfrescoPersonPropertyLastName;

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.m
@@ -25,6 +25,7 @@
 NSString * const kAlfrescoClassVersion = @"alfresco.classVersion";
 
 NSString * const kAlfrescoISO8601DateStringFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZ";
+
 /**
  CMIS constants
  */
@@ -33,16 +34,18 @@ NSString * const kAlfrescoCMISPropertyTypeBoolean = @"boolean";
 NSString * const kAlfrescoCMISPropertyTypeDatetime = @"datetime";
 NSString * const kAlfrescoCMISPropertyTypeDecimal = @"decimal";
 NSString * const kAlfrescoCMISPropertyTypeId = @"id";
-NSString * const kAlfrescoCMISSessionMode = @"alfresco";
+NSString * const kAlfrescoCMISNetworkProvider = @"org.alfresco.mobile.internal.session.cmis.networkprovider";
+NSString * const kAlfrescoCMISModelPrefix = @"cmis:";
+NSString * const kAlfrescoCMISFolderTypePrefix = @"F:";
+NSString * const kAlfrescoCMISDocumentTypePrefix = @"D:";
+NSString * const kAlfrescoCMISAspectPrefix = @"P:";
 
 /**
  Content Model constants
  */
-NSString * const kAlfrescoPropertyName = @"cm:name";
-NSString * const kAlfrescoPropertyTitle = @"cm:title";
-NSString * const kAlfrescoPropertyDescription = @"cm:description";
-NSString * const kAlfrescoTypeContent = @"cm:content";
-NSString * const kAlfrescoTypeFolder = @"cm:folder";
+NSString * const kAlfrescoContentModelPrefix = @"cm:";
+NSString * const kAlfrescoSystemModelPrefix = @"sys:";
+NSString * const kAlfrescoSystemModelAspectLocalized = @"sys:localized";
 
 /**
  Property name constants
@@ -372,10 +375,6 @@ NSString * const kAlfrescoHTTPPOST = @"POST";
 NSString * const kAlfrescoHTTPPut = @"PUT";
 
 NSString * const kAlfrescoFileManagerClass = @"AlfrescoFileManagerClassName";
-NSString * const kAlfrescoCMISNetworkProvider = @"org.alfresco.mobile.internal.session.cmis.networkprovider";
-NSString * const kAlfrescoPropertyTypeFolder = @"F:";
-NSString * const kAlfrescoPropertyTypeDocument = @"D:";
-NSString * const kAlfrescoPropertyAspect = @"P:";
 
 /**
  Person Profile Constants

--- a/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoDocument.m
+++ b/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoDocument.m
@@ -68,8 +68,8 @@ static NSInteger kDocumentModelVersion = 1;
     [super encodeWithCoder:aCoder];
     
     [aCoder encodeInteger:kDocumentModelVersion forKey:NSStringFromClass([self class])];
-    [aCoder encodeBool:self.isFolder forKey:kAlfrescoPropertyTypeFolder];
-    [aCoder encodeBool:self.isDocument forKey:kAlfrescoPropertyTypeDocument];
+    [aCoder encodeBool:self.isFolder forKey:kAlfrescoCMISFolderTypePrefix];
+    [aCoder encodeBool:self.isDocument forKey:kAlfrescoCMISDocumentTypePrefix];
     [aCoder encodeBool:self.isLatestVersion forKey:kCMISPropertyIsLatestVersion];
     [aCoder encodeInt64:self.contentLength forKey:kCMISPropertyContentStreamLength];
     [aCoder encodeObject:self.contentMimeType forKey:kCMISPropertyContentStreamMediaType];
@@ -85,8 +85,8 @@ static NSInteger kDocumentModelVersion = 1;
     {
         //uncomment this line if you need to check the model version
 //        NSInteger version = [aDecoder decodeIntForKey:NSStringFromClass([self class])];
-        self.isFolder = [aDecoder decodeBoolForKey:kAlfrescoPropertyTypeFolder];
-        self.isDocument = [aDecoder decodeBoolForKey:kAlfrescoPropertyTypeDocument];
+        self.isFolder = [aDecoder decodeBoolForKey:kAlfrescoCMISFolderTypePrefix];
+        self.isDocument = [aDecoder decodeBoolForKey:kAlfrescoCMISDocumentTypePrefix];
         self.isLatestVersion = [aDecoder decodeBoolForKey:kCMISPropertyIsLatestVersion];
         self.contentLength = [aDecoder decodeInt64ForKey:kCMISPropertyContentStreamLength];
         self.contentMimeType = [aDecoder decodeObjectForKey:kCMISPropertyContentStreamMediaType];

--- a/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoFolder.m
+++ b/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoFolder.m
@@ -47,8 +47,8 @@ static NSInteger kFolderModelVersion = 1;
     [super encodeWithCoder:aCoder];
 
     [aCoder encodeInteger:kFolderModelVersion forKey:NSStringFromClass([self class])];
-    [aCoder encodeBool:self.isFolder forKey:kAlfrescoPropertyTypeFolder];
-    [aCoder encodeBool:self.isDocument forKey:kAlfrescoPropertyTypeDocument];
+    [aCoder encodeBool:self.isFolder forKey:kAlfrescoCMISFolderTypePrefix];
+    [aCoder encodeBool:self.isDocument forKey:kAlfrescoCMISDocumentTypePrefix];
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder
@@ -59,8 +59,8 @@ static NSInteger kFolderModelVersion = 1;
     {
         //uncomment this line if you need to check the model version
 //        NSInteger version = [aDecoder decodeIntForKey:NSStringFromClass([self class])];
-        self.isFolder = [aDecoder decodeBoolForKey:kAlfrescoPropertyTypeFolder];
-        self.isDocument = [aDecoder decodeBoolForKey:kAlfrescoPropertyTypeDocument];
+        self.isFolder = [aDecoder decodeBoolForKey:kAlfrescoCMISFolderTypePrefix];
+        self.isDocument = [aDecoder decodeBoolForKey:kAlfrescoCMISDocumentTypePrefix];
     }
     return self;
 }

--- a/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoNode.m
+++ b/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoNode.m
@@ -18,6 +18,7 @@
 
 #import "AlfrescoNode.h"
 #import "AlfrescoProperty.h"
+#import "AlfrescoConstants.h"
 #import "AlfrescoInternalConstants.h"
 #import "CMISConstants.h"
 
@@ -97,13 +98,13 @@ NSString * const kAlfrescoPermissionsObjectKey = @"AlfrescoPermissionsObjectKey"
         self.modifiedAt = [properties valueForKey:kCMISPropertyModificationDate];
     }
     
-    if ([[properties allKeys] containsObject:kAlfrescoPropertyTitle])
+    if ([[properties allKeys] containsObject:kAlfrescoContentModelPropertyTitle])
     {
-        self.title = [properties valueForKey:kAlfrescoPropertyTitle];
+        self.title = [properties valueForKey:kAlfrescoContentModelPropertyTitle];
     }
-    if ([[properties allKeys] containsObject:kAlfrescoPropertyDescription])
+    if ([[properties allKeys] containsObject:kAlfrescoContentModelPropertyDescription])
     {
-        self.summary = [properties valueForKey:kAlfrescoPropertyDescription];
+        self.summary = [properties valueForKey:kAlfrescoContentModelPropertyDescription];
     }
     if ([[properties allKeys] containsObject:kAlfrescoNodeAspects])
     {
@@ -120,8 +121,8 @@ NSString * const kAlfrescoPermissionsObjectKey = @"AlfrescoPermissionsObjectKey"
     [aCoder encodeInteger:kNodeModelVersion forKey:NSStringFromClass([self class])];
     [aCoder encodeObject:self.identifier forKey:kCMISPropertyObjectId];
     [aCoder encodeObject:self.name forKey:kCMISPropertyName];
-    [aCoder encodeObject:self.title forKey:kAlfrescoPropertyTitle];
-    [aCoder encodeObject:self.summary forKey:kAlfrescoPropertyDescription];
+    [aCoder encodeObject:self.title forKey:kAlfrescoContentModelPropertyTitle];
+    [aCoder encodeObject:self.summary forKey:kAlfrescoContentModelPropertyDescription];
     [aCoder encodeObject:self.type forKey:kCMISPropertyObjectTypeId];
     [aCoder encodeObject:self.createdAt forKey:kCMISPropertyCreationDate];
     [aCoder encodeObject:self.createdBy forKey:kCMISPropertyCreatedBy];
@@ -140,8 +141,8 @@ NSString * const kAlfrescoPermissionsObjectKey = @"AlfrescoPermissionsObjectKey"
 //        NSInteger version = [aDecoder decodeIntForKey:NSStringFromClass([self class])];
         self.identifier = [aDecoder decodeObjectForKey:kCMISPropertyObjectId];
         self.name = [aDecoder decodeObjectForKey:kCMISPropertyName];
-        self.title = [aDecoder decodeObjectForKey:kAlfrescoPropertyTitle];
-        self.summary = [aDecoder decodeObjectForKey:kAlfrescoPropertyDescription];
+        self.title = [aDecoder decodeObjectForKey:kAlfrescoContentModelPropertyTitle];
+        self.summary = [aDecoder decodeObjectForKey:kAlfrescoContentModelPropertyDescription];
         self.type = [aDecoder decodeObjectForKey:kCMISPropertyObjectTypeId];
         self.createdAt = [aDecoder decodeObjectForKey:kCMISPropertyCreationDate];
         self.createdBy = [aDecoder decodeObjectForKey:kCMISPropertyCreatedBy];

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoCMISToAlfrescoObjectConverter.m
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoCMISToAlfrescoObjectConverter.m
@@ -70,7 +70,7 @@
     }
     if (![objectType isEqualToString:emptyString])
     {
-        NSString *alfrescoObjectType = [objectType stringByReplacingOccurrencesOfString:kCMISPropertyObjectTypeIdValueFolder withString:kAlfrescoTypeFolder];
+        NSString *alfrescoObjectType = [objectType stringByReplacingOccurrencesOfString:kCMISPropertyObjectTypeIdValueFolder withString:kAlfrescoContentModelTypeFolder];
         [properties setValue:[AlfrescoCMISToAlfrescoObjectConverter propertyValueWithoutPrecursor:alfrescoObjectType] forKey:kCMISPropertyObjectTypeId];
     }
     if (![createdBy isEqualToString:emptyString])
@@ -113,7 +113,7 @@
     }
     if (![objectType isEqualToString:emptyString])
     {
-        NSString *alfrescoObjectType = [objectType stringByReplacingOccurrencesOfString:kCMISPropertyObjectTypeIdValueDocument withString:kAlfrescoTypeContent];
+        NSString *alfrescoObjectType = [objectType stringByReplacingOccurrencesOfString:kCMISPropertyObjectTypeIdValueDocument withString:kAlfrescoContentModelTypeContent];
         [properties setValue:[AlfrescoCMISToAlfrescoObjectConverter propertyValueWithoutPrecursor:alfrescoObjectType] forKey:kCMISPropertyObjectTypeId];
     }
     if (![createdBy isEqualToString:emptyString])
@@ -186,15 +186,15 @@
                 NSString *correctedString = [AlfrescoCMISToAlfrescoObjectConverter propertyValueWithoutPrecursor:type];
                 [strippedAspectTypes addObject:correctedString];
             }
-            NSString *title = [folder.properties propertyValueForId:kAlfrescoPropertyTitle];
+            NSString *title = [folder.properties propertyValueForId:kAlfrescoContentModelPropertyTitle];
             if (![title isEqualToString:@"(null)"])
             {
-                [propertyDictionary setValue:title forKey:kAlfrescoPropertyTitle];
+                [propertyDictionary setValue:title forKey:kAlfrescoContentModelPropertyTitle];
             }
-            NSString *description = [folder.properties propertyValueForId:kAlfrescoPropertyDescription];
+            NSString *description = [folder.properties propertyValueForId:kAlfrescoContentModelPropertyDescription];
             if (![description isEqualToString:@"(null)"])
             {
-                [propertyDictionary setValue:description forKey:kAlfrescoPropertyDescription];
+                [propertyDictionary setValue:description forKey:kAlfrescoContentModelPropertyDescription];
             }
             [propertyDictionary setValue:strippedAspectTypes forKey:kAlfrescoNodeAspects];
         }
@@ -212,15 +212,15 @@
                 NSString *correctedString = [AlfrescoCMISToAlfrescoObjectConverter propertyValueWithoutPrecursor:type];
                 [strippedAspectTypes addObject:correctedString];
             }
-            NSString *title = [document.properties propertyValueForId:kAlfrescoPropertyTitle];
+            NSString *title = [document.properties propertyValueForId:kAlfrescoContentModelPropertyTitle];
             if (![title isEqualToString:@"(null)"])
             {
-                [propertyDictionary setValue:title forKey:kAlfrescoPropertyTitle];
+                [propertyDictionary setValue:title forKey:kAlfrescoContentModelPropertyTitle];
             }
-            NSString *description = [document.properties propertyValueForId:kAlfrescoPropertyDescription];
+            NSString *description = [document.properties propertyValueForId:kAlfrescoContentModelPropertyDescription];
             if (![description isEqualToString:@"(null)"])
             {
-                [propertyDictionary setValue:description forKey:kAlfrescoPropertyDescription];
+                [propertyDictionary setValue:description forKey:kAlfrescoContentModelPropertyDescription];
             }
             
             [propertyDictionary setValue:strippedAspectTypes forKey:kAlfrescoNodeAspects];
@@ -289,17 +289,17 @@
 
 + (NSString *)propertyValueWithoutPrecursor:(NSString *)value
 {
-    if ([value hasPrefix:@"P:"])
+    if ([value hasPrefix:kAlfrescoCMISAspectPrefix])
     {
-        return [value stringByReplacingOccurrencesOfString:@"P:" withString:@""];
+        return [value stringByReplacingOccurrencesOfString:kAlfrescoCMISAspectPrefix withString:@""];
     }
-    else if([value hasPrefix:@"D:"])
+    else if([value hasPrefix:kAlfrescoCMISDocumentTypePrefix])
     {
-        return [value stringByReplacingOccurrencesOfString:@"D:" withString:@""];
+        return [value stringByReplacingOccurrencesOfString:kAlfrescoCMISDocumentTypePrefix withString:@""];
     }
-    else if ([value hasPrefix:@"F:"])
+    else if ([value hasPrefix:kAlfrescoCMISFolderTypePrefix])
     {
-        return [value stringByReplacingOccurrencesOfString:@"F:" withString:@""];
+        return [value stringByReplacingOccurrencesOfString:kAlfrescoCMISFolderTypePrefix withString:@""];
     }
     return value;
 }

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoSpecificCMISTests.m
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoSpecificCMISTests.m
@@ -23,6 +23,7 @@
 #import "CMISDateUtil.h"
 #import "AlfrescoCMISDocument.h"
 #import "AlfrescoInternalConstants.h"
+#import "AlfrescoCMISUtil.h"
 
 // TODO: Maintain these tests on an 'alfresco' branch, also remove the Alfresco specific code from master.
 
@@ -188,118 +189,6 @@ static NSString * const kAlfrescoTestNetworkID = @"/alfresco.com";
     }
 }
 
-/*
-- (void)testUpdateDocumentDescription
-{
-    [self runCMISTest:^
-    {
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"test_file.txt" ofType:nil];
-        NSURL *fileUrl = [NSURL URLWithString:filePath];
-        NSString *documentName = [AlfrescoBaseTest testFileNameFromFilename:[fileUrl lastPathComponent]];
-        NSMutableDictionary *documentProperties = [NSMutableDictionary dictionary];
-        [documentProperties setObject:documentName forKey:kCMISPropertyName];
-        
-        NSMutableString *objectTypeId = [[NSMutableString alloc] init];
-        [objectTypeId appendString:@"cmis:document"];
-        [objectTypeId appendFormat:@", P:cm:titled"];
-        
-        [documentProperties setObject:objectTypeId forKey:kCMISPropertyObjectTypeId];
-        [self.cmisRootFolder createDocumentFromFilePath:filePath withMimeType:@"text/plain" withProperties:documentProperties completionBlock:^(NSString *objectId, NSError *error){
-            if (nil == objectId)
-            {
-                self.lastTestSuccessful = NO;
-                self.callbackCompleted = YES;
-                self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [error localizedDescription], [error localizedFailureReason]];
-            }
-            else
-            {
-                [self.cmisSession retrieveObject:objectId completionBlock:^(CMISObject *cmisObject, NSError *objError){
-                    if (nil == cmisObject)
-                    {
-                        self.lastTestSuccessful = NO;
-                        self.callbackCompleted = YES;
-                        self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [objError localizedDescription], [objError localizedFailureReason]];
-                    }
-                    else
-                    {
-                        CMISDocument *doc = (CMISDocument *)cmisObject;
-                        NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-                        NSString *description = @"This is a jolly good description!";
-                        [properties setObject:description forKey:@"cm:description"];
-                        [documentProperties setObject:@"cmis:document, P:cm:titled" forKey:kCMISPropertyObjectTypeId];
-                        
-                        [self.cmisSession.objectConverter convertProperties:properties forObjectTypeId:cmisObject.objectType completionBlock:^(CMISProperties *convertedProps, NSError *convError){
-                            if (nil == convertedProps)
-                            {
-                                self.lastTestSuccessful = NO;
-                                self.callbackCompleted = YES;
-                                self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [convError localizedDescription], [convError localizedFailureReason]];
-                            }
-                            else
-                            {
-                                CMISProperties *updatedProperties = [[CMISProperties alloc] init];
-                                NSEnumerator *enumerator = [convertedProps.propertiesDictionary keyEnumerator];
-                                for (NSString *cmisKey in enumerator)
-                                {
-                                    if (![cmisKey isEqualToString:kCMISPropertyObjectTypeId])
-                                    {
-                                        CMISPropertyData *propData = [convertedProps.propertiesDictionary objectForKey:cmisKey];
-                                        [updatedProperties addProperty:propData];
-                                    }
-                                }
-                                updatedProperties.extensions = convertedProps.extensions;
-                                CMISStringInOutParameter *inOut = [CMISStringInOutParameter inOutParameterUsingInParameter:cmisObject.identifier];
-                                [self.cmisSession.binding.objectService updatePropertiesForObject:inOut withProperties:updatedProperties withChangeToken:nil completionBlock:^(NSError *updError){
-                                    if (updError)
-                                    {
-                                        self.lastTestSuccessful = NO;
-                                        self.callbackCompleted = YES;
-                                        self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [convError localizedDescription], [convError localizedFailureReason]];
-                                    }
-                                    else
-                                    {
-                                        [self.cmisSession retrieveObject:cmisObject.identifier completionBlock:^(CMISObject *updatedObj, NSError *retrError){
-                                            if (nil == updatedObj)
-                                            {
-                                                self.lastTestSuccessful = NO;
-                                                self.callbackCompleted = YES;
-                                                self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [retrError localizedDescription], [retrError localizedFailureReason]];
-                                            }
-                                            else
-                                            {
-                                                CMISDocument *doc = (CMISDocument *)updatedObj;
-                                                [self verifyDocument:doc hasExtensionProperty:@"cm:description" withValue:description];
-                                                [doc deleteAllVersionsWithCompletionBlock:^(BOOL documentDeleted, NSError *deleteError){
-                                                    if (deleteError)
-                                                    {
-                                                        self.lastTestSuccessful = NO;
-                                                        self.callbackCompleted = YES;
-                                                        self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [deleteError localizedDescription], [deleteError localizedFailureReason]];
-                                                    }
-                                                    else
-                                                    {
-                                                        self.lastTestSuccessful = YES;
-                                                        self.callbackCompleted = YES;
-                                                    }
-                                                }];
-                                                
-                                            }
-                                        }];
-                                    }
-                                }];
-                            }
-                        }];
-                        
-                    }
-                }];
-            }
-        } progressBlock:^(unsigned long long bytesUploaded, unsigned long long bytesTotal){}];
-        [self waitUntilCompleteWithFixedTimeInterval];
-        XCTAssertTrue(self.lastTestSuccessful, @"testUpdateDocumentDescription failed");
-
-    }];
-}
-*/
 - (void)testRetrieveExifDataUsingExtensions
 {
     if (self.setUpSuccess)
@@ -367,91 +256,6 @@ static NSString * const kAlfrescoTestNetworkID = @"/alfresco.com";
         XCTFail(@"Could not run test case: %@", NSStringFromSelector(_cmd));
     }
 }
-
-/*
-- (void)testUpdateExifData
-{
-    [self runCMISTest:^
-    {
-        NSString *originalModelName = @"E950";
-
-        NSDate *originalDate = [[CMISDateUtil defaultDateFormatter] dateFromString:@"2012-10-19T00:00:00.000Z"];
-        NSDate *now = [NSDate date];
-        NSString *testFilePath = [self.testFolderPathName stringByAppendingPathComponent:@"image-with-exif.jpg"];
- 
-        [self.cmisSession retrieveObjectByPath:testFilePath completionBlock:^(CMISObject *cmisObject, NSError *error){
-            if (nil == cmisObject)
-            {
-                self.lastTestSuccessful = NO;
-                self.callbackCompleted = YES;
-                self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [error localizedDescription], [error localizedFailureReason]];
-            }
-            else
-            {
-                CMISDocument *document = (CMISDocument *)cmisObject;
-                [self verifyDocument:document hasExtensionProperty:@"exif:model" withValue:originalModelName];
-                [self verifyDocument:document hasExtensionProperty:@"exif:pixelYDimension" withValue:@"600"];
-                [self verifyDocument:document hasExtensionProperty:@"exif:flash" withValue:@"false"];
-                [self verifyDocument:document hasExtensionProperty:@"exif:dateTimeOriginal" withValue:[[CMISDateUtil defaultDateFormatter] stringFromDate:originalDate]];
-
-                
-                NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-                NSString *newModelName = @"Ultimate Flash Model 101";
-                [properties setValue:newModelName forKey:@"exif:model"];
-                [properties setValue:[NSNumber numberWithInt:101] forKey:@"exif:pixelYDimension"];
-                [properties setValue:[NSNumber numberWithBool:YES] forKey:@"exif:flash"];
-                [properties setValue:now forKey:@"exif:dateTimeOriginal"];
-                
-                [document updateProperties:properties completionBlock:^(CMISObject *updatedObject, NSError *updateError){
-                    if (nil == updatedObject)
-                    {
-                        self.lastTestSuccessful = NO;
-                        self.callbackCompleted = YES;
-                        self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [updateError localizedDescription], [updateError localizedFailureReason]];
-                    }
-                    else
-                    {
-                        [self verifyDocument:document hasExtensionProperty:@"exif:model" withValue:newModelName];
-                        [self verifyDocument:document hasExtensionProperty:@"exif:pixelYDimension" withValue:@"101"];
-                        [self verifyDocument:document hasExtensionProperty:@"exif:flash" withValue:@"true"];
-                        [self verifyDocument:document hasExtensionProperty:@"exif:dateTimeOriginal" withValue:[[CMISDateUtil defaultDateFormatter] stringFromDate:now]];
-                        
-                        NSMutableDictionary *resetProperties = [NSMutableDictionary dictionary];
-                        [resetProperties setValue:originalModelName forKey:@"exif:model"];
-                        [resetProperties setValue:[NSNumber numberWithInt:600] forKey:@"exif:pixelYDimension"];
-                        [resetProperties setValue:[NSNumber numberWithBool:NO] forKey:@"exif:flash"];
-                        [resetProperties setValue:originalDate forKey:@"exif:dateTimeOriginal"];
-                        
-                        CMISDocument *updatedDoc = (CMISDocument *)updatedObject;
-                        [updatedDoc updateProperties:resetProperties completionBlock:^(CMISObject *resetObj, NSError *resetError){
-                            if (nil == resetObj)
-                            {
-                                self.lastTestSuccessful = NO;
-                                self.callbackCompleted = YES;
-                                self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [resetError localizedDescription], [resetError localizedFailureReason]];
-                            }
-                            else
-                            {
-                                
-                                self.lastTestSuccessful = YES;
-                                [self verifyDocument:document hasExtensionProperty:@"exif:model" withValue:originalModelName];
-                                [self verifyDocument:document hasExtensionProperty:@"exif:pixelYDimension" withValue:@"600"];
-                                [self verifyDocument:document hasExtensionProperty:@"exif:flash" withValue:@"false"];
-                                [self verifyDocument:document hasExtensionProperty:@"exif:dateTimeOriginal" withValue:[[CMISDateUtil defaultDateFormatter] stringFromDate:originalDate]];
-                                self.callbackCompleted = YES;
-                            }
-                        }];
-                    }
-                }];
-                
-            }
-        }];
-        [self waitUntilCompleteWithFixedTimeInterval];
-        XCTAssertTrue(self.lastTestSuccessful, @"testUpdateExifData failed");
-        
-    }];
-}
-*/
  
 - (void)testCreateDocumentWithExif
 {
@@ -656,53 +460,102 @@ static NSString * const kAlfrescoTestNetworkID = @"/alfresco.com";
     }
 }
 
-//- (void)testCreateDocumentWithJapaneseProperties
-//{
-//    [self runTest:^
-//    {
-//        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"test_file.txt" ofType:nil];
-//
-//        NSMutableDictionary *documentProperties = [NSMutableDictionary dictionary];
-//        [documentProperties setObject:@"cmis:document, P:cm:titled, P:cm:author" forKey:kCMISPropertyObjectTypeId];
-//
-//        NSString *documentName = @"ラヂオコmプタ";
-//        [documentProperties setObject:documentName forKey:kCMISPropertyName];
-//
-//        NSString *title = @"わさび";
-//        [documentProperties setObject:title forKey:@"cm:title"];
-//
-//        NSString *description = @"ありがと　にほんご";
-//        [documentProperties setObject:description forKey:@"cm:description"];
-//
-//        // Upload test file
-//        __block NSString *objectId = nil;
-//        [self.testFolder createDocumentFromFilePath:filePath
-//                withMimeType:@"text/plain"
-//                withProperties:documentProperties
-//                completionBlock: ^ (NSString *newObjectId)
-//                {
-//                    XCTAssertNotNil(newObjectId, @"Object id should not be nil");
-//                    objectId = newObjectId;
-//                    self.callbackCompleted = YES;
-//                }
-//                failureBlock: ^ (NSError *failureError)
-//                {
-//                    XCTAssertNil(failureError, @"Got error while uploading document: %@", [failureError description]);
-//                }
-//                progressBlock:nil];
-//
-//        [self waitForCompletion:60];
-//
-//        NSError *error = nil;
-//        CMISDocument *document = (CMISDocument *) [self.session retrieveObject:objectId error:&error];
-//        XCTAssertNil(error, @"Got error while creating document: %@", [error description]);
-//        XCTAssertEquals([document.properties propertyValueForId:@"cm:title"], title, @"Expected %@, but was %@", [document.properties propertyValueForId:@"cm:title"], title);
-//        XCTAssertEquals([document.properties propertyValueForId:@"cm:description"], description, @"Expected %@, but was %@", [document.properties propertyValueForId:@"cm:description"], description);
-//
-//        // Clean up
-//        [self deleteDocumentAndVerify:document];
-//    }];
-//}
+- (void)testObjectTypeIdHelper
+{
+    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+    
+    // test just the folder parameter being set
+    NSString *objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:nil aspects:nil folder:YES];
+    XCTAssertTrue([objectTypeId isEqualToString:kCMISPropertyObjectTypeIdValueFolder],
+                  @"Expected objectTypeId to be %@ but it was %@", kCMISPropertyObjectTypeIdValueFolder, objectTypeId);
+    
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:nil aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:kCMISPropertyObjectTypeIdValueDocument],
+                  @"Expected objectTypeId to be %@ but it was %@", kCMISPropertyObjectTypeIdValueDocument, objectTypeId);
+    
+    // test just cm:content as type
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:kAlfrescoContentModelTypeContent aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:kCMISPropertyObjectTypeIdValueDocument],
+                  @"Expected objectTypeId to be %@ but it was %@", kCMISPropertyObjectTypeIdValueDocument, objectTypeId);
+    
+    // test just cm:folder as type
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:kAlfrescoContentModelTypeFolder aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:kCMISPropertyObjectTypeIdValueFolder],
+                  @"Expected objectTypeId to be %@ but it was %@", kCMISPropertyObjectTypeIdValueFolder, objectTypeId);
+    
+    // test just cmis:document as type
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:kCMISPropertyObjectTypeIdValueDocument aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:kCMISPropertyObjectTypeIdValueDocument],
+                  @"Expected objectTypeId to be %@ but it was %@", kCMISPropertyObjectTypeIdValueDocument, objectTypeId);
+    
+    // test just cmis:folder as type
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:kCMISPropertyObjectTypeIdValueFolder aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:kCMISPropertyObjectTypeIdValueFolder],
+                  @"Expected objectTypeId to be %@ but it was %@", kCMISPropertyObjectTypeIdValueFolder, objectTypeId);
+    
+    // test just custom type
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:@"fdk:everything" aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"D:fdk:everything"],
+                  @"Expected objectTypeId to be D:fdk:everything but it was %@", objectTypeId);
+    
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:@"st:site" aspects:nil folder:YES];
+    XCTAssertTrue([objectTypeId isEqualToString:@"F:st:site"],
+                  @"Expected objectTypeId to be F:st:site but it was %@", objectTypeId);
+    
+    // test just aspects
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:nil aspects:@[kAlfrescoContentModelAspectTitled, kAlfrescoContentModelAspectAuthor] folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:titled,P:cm:author"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:titled,P:cm:author but it was %@", objectTypeId);
+    
+    // test aspect and type
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:kAlfrescoContentModelTypeFolder aspects:@[kAlfrescoContentModelAspectTitled] folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:folder,P:cm:titled"],
+                  @"Expected objectTypeId to be cmis:folder,P:cm:titled but it was %@", objectTypeId);
+    
+    // test custom type and aspect
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:nil type:@"fdk:everything" aspects:@[kAlfrescoContentModelAspectTitled] folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"D:fdk:everything,P:cm:titled"],
+                  @"Expected objectTypeId to be D:fdk:everything,P:cm:titled but it was %@", objectTypeId);
+    
+    // test cmis:objectTypeId already being set i.e. no adverse effects
+    properties[kCMISPropertyObjectTypeId] = @"cmis:document,P:cm:titled";
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:properties type:nil aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:titled"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:titled but it was %@", objectTypeId);
+    
+    // test cmis:objectTypeId already being set (to Alfresco type) plus a given aspect
+    properties[kCMISPropertyObjectTypeId] = @"cm:content,P:cm:titled";
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:properties type:nil aspects:@[kAlfrescoContentModelAspectAuthor] folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:titled,P:cm:author"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:titled,P:cm:author but it was %@", objectTypeId);
+    
+    // test aspects being applied by their presence in the dictionary
+    properties[kAlfrescoContentModelPropertyTitle] = @"A Title";
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:properties type:kAlfrescoContentModelTypeContent aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:titled"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:titled but it was %@", objectTypeId);
+    
+    properties[kAlfrescoContentModelPropertyLatitude] = @(51.52255);
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:properties type:kAlfrescoContentModelTypeContent aspects:nil folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:titled,P:cm:geographic"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:titled,P:cm:geographic but it was %@", objectTypeId);
+    
+    // test aspects being applied by their presence in the dictionary and given as a parameter
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:properties type:kAlfrescoContentModelTypeContent aspects:@[kAlfrescoContentModelAspectAuthor] folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:author,P:cm:titled,P:cm:geographic"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:author,P:cm:titled,P:cm:geographic but it was %@", objectTypeId);
+    
+    // test that we don't get duplicated aspects or system aspects
+    objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:properties
+                                                                 type:kAlfrescoContentModelTypeContent
+                                                              aspects:@[kAlfrescoContentModelAspectTitled,
+                                                                        kAlfrescoContentModelAspectAuthor,
+                                                                        kAlfrescoContentModelAspectGeographic,
+                                                                        kAlfrescoSystemModelAspectLocalized]
+                                                               folder:NO];
+    XCTAssertTrue([objectTypeId isEqualToString:@"cmis:document,P:cm:titled,P:cm:author,P:cm:geographic"],
+                  @"Expected objectTypeId to be cmis:document,P:cm:titled,P:cm:author,P:cm:geographic but it was %@", objectTypeId);
+}
 
 #pragma mark Helper methods
 
@@ -761,57 +614,5 @@ static NSString * const kAlfrescoTestNetworkID = @"/alfresco.com";
     XCTAssertTrue([valueElement.value isEqual:expectedValue],
         @"Document property '%@' value does not match: was %@ but expected %@", expectedProperty, valueElement.value, expectedValue);
 }
-
-/*
-- (CMISDocument *)uploadTestFileWithAspects:(NSArray *)aspectTypeIds
-{
-    // Set properties on test file
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"test_file.txt" ofType:nil];
-    NSString *documentName = [NSString stringWithFormat:@"test_file_%@.txt", [self stringFromCurrentDate]];
-    NSMutableDictionary *documentProperties = [NSMutableDictionary dictionary];
-    [documentProperties setObject:documentName forKey:kCMISPropertyName];
-
-    NSMutableString *objectTypeId = [[NSMutableString alloc] init];
-    [objectTypeId appendString:@"cmis:document"];
-    for (NSString *aspectTypeId in aspectTypeIds)
-    {
-        [objectTypeId appendFormat:@", %@", aspectTypeId];
-    }
-    [documentProperties setObject:objectTypeId forKey:kCMISPropertyObjectTypeId];
-
-    // Upload test file
-    __block NSInteger previousUploadedBytes = -1;
-    __block NSString *objectId = nil;
-    [self.testFolder createDocumentFromFilePath:filePath
-            withMimeType:@"text/plain"
-            withProperties:documentProperties
-            completionBlock: ^ (NSString *newObjectId)
-            {
-                XCTAssertNotNil(newObjectId, @"Object id should not be nil");
-                objectId = newObjectId;
-                self.callbackCompleted = YES;
-            }
-            failureBlock: ^ (NSError *failureError)
-            {
-                XCTAssertNil(failureError, @"Got error while uploading document: %@", [failureError description]);
-            }
-            progressBlock: ^ (NSInteger uploadedBytes, NSInteger totalBytes)
-            {
-                XCTAssertTrue(uploadedBytes > previousUploadedBytes, @"no progress");
-                previousUploadedBytes = uploadedBytes;
-            }];
-
-    [self waitUntilCompleteWithFixedTimeInterval];
-
-    NSError *error = nil;
-    CMISDocument *document = (CMISDocument *) [self.session retrieveObject:objectId error:&error];
-    XCTAssertNil(error, @"Got error while creating document: %@", [error description]);
-    XCTAssertNotNil(objectId, @"Object id received should be non-nil");
-    XCTAssertNotNil(document, @"Retrieved document should not be nil");
-
-    return document;
-}
-*/
-
 
 @end

--- a/AlfrescoSDK/CMIS/AlfrescoCMIS/AlfrescoCMISObjectConverter.m
+++ b/AlfrescoSDK/CMIS/AlfrescoCMIS/AlfrescoCMISObjectConverter.m
@@ -32,6 +32,7 @@
 #import "CMISDateUtil.h"
 #import "AlfrescoErrors.h"
 #import "AlfrescoConstants.h"
+#import "AlfrescoInternalConstants.h"
 
 @interface AlfrescoCMISObjectConverter ()
 - (void)retrieveAspectTypeDefinitionsFromObjectID:(NSString *)objectID completionBlock:(AlfrescoArrayCompletionBlock)completionBlock;
@@ -303,7 +304,7 @@
     CMISTypeDefinition *typeDefinition = nil;
     for (CMISTypeDefinition * type in typeArray)
     {
-        if ([type.id hasPrefix:@"cmis:"] || [type.id hasPrefix:@"D:"] || [type.id hasPrefix:@"F:"])
+        if ([type.id hasPrefix:kAlfrescoCMISModelPrefix] || [type.id hasPrefix:kAlfrescoCMISDocumentTypePrefix] || [type.id hasPrefix:kAlfrescoCMISFolderTypePrefix])
         {
             typeDefinition = type;
             break;
@@ -317,7 +318,7 @@
     NSMutableArray *aspects = [NSMutableArray array];
     for (CMISTypeDefinition * type in typeArray)
     {
-        if (![type.id hasPrefix:@"cmis:"] && ![type.id hasPrefix:@"D:"] && ![type.id hasPrefix:@"F:"])
+        if (![type.id hasPrefix:kAlfrescoCMISModelPrefix] && ![type.id hasPrefix:kAlfrescoCMISDocumentTypePrefix] && ![type.id hasPrefix:kAlfrescoCMISFolderTypePrefix])
         {
             [aspects addObject:type];
         }

--- a/AlfrescoSDK/CMIS/AlfrescoCMIS/AlfrescoCMISUtil.h
+++ b/AlfrescoSDK/CMIS/AlfrescoCMIS/AlfrescoCMISUtil.h
@@ -22,8 +22,9 @@
 // AlfrescoCMISUtil 
 //
 #import <Foundation/Foundation.h>
+#import "AlfrescoNode.h"
 
-@class CMISObject;
+@class CMISObject, CMISProperties, CMISSession;
 
 
 @interface AlfrescoCMISUtil : NSObject
@@ -39,5 +40,21 @@
  maps CMIS errors to Alfresco Errors
  */
 + (NSError *)alfrescoErrorWithCMISError:(NSError *)cmisError;
+
+/**
+ * Prepares the CMIS objectTypeId property for the given set of properties.
+ */
++ (NSString *)prepareObjectTypeIdForProperties:(NSDictionary *)alfrescoProperties
+                                          type:(NSString *)type
+                                       aspects:(NSArray *)aspects
+                                        folder:(BOOL)folder;
+
+/**
+ * Prepares the given dictionary of Alfresco properties for update via CMIS
+ */
++ (void)preparePropertiesForUpdate:(NSDictionary *)alfrescoProperties
+                              node:(AlfrescoNode *)node
+                       cmisSession:(CMISSession *)cmisSession
+                   completionBlock:(void (^)(CMISProperties *cmisProperties, NSError *error))completionBlock;
 
 @end

--- a/AlfrescoSDK/CMIS/AlfrescoCMIS/AlfrescoCMISUtil.m
+++ b/AlfrescoSDK/CMIS/AlfrescoCMIS/AlfrescoCMISUtil.m
@@ -26,7 +26,12 @@
 #import "CMISAtomPubConstants.h"
 #import "CMISAtomParserUtil.h"
 #import "CMISErrors.h"
+#import "CMISConstants.h"
+#import "CMISSession.h"
+#import "CMISObjectConverter.h"
 #import "AlfrescoErrors.h"
+#import "AlfrescoConstants.h"
+#import "AlfrescoInternalConstants.h"
 
 #define ALFRESCO_EXTENSION_ASPECTS @"aspects"
 #define ALFRESCO_EXTENSION_APPLIED_ASPECTS @"appliedAspects"
@@ -175,5 +180,197 @@
     return alfrescoError;
 }
 
++ (NSString *)prepareObjectTypeIdForProperties:(NSDictionary *)alfrescoProperties
+                                          type:(NSString *)type
+                                       aspects:(NSArray *)aspects
+                                        folder:(BOOL)folder
+{
+    NSString *cmisTypeId = nil;
+    
+    // use the type if present (takes precedence over the property)
+    if (type != nil)
+    {
+        // first check whether it's one of the base Alfresco types
+        if ([type isEqualToString:kAlfrescoContentModelTypeContent])
+        {
+            cmisTypeId = kCMISPropertyObjectTypeIdValueDocument;
+        }
+        else if ([type isEqualToString:kAlfrescoContentModelTypeFolder])
+        {
+            cmisTypeId = kCMISPropertyObjectTypeIdValueFolder;
+        }
+        else if ([type isEqualToString:kCMISPropertyObjectTypeIdValueDocument])
+        {
+            cmisTypeId = kCMISPropertyObjectTypeIdValueDocument;
+        }
+        else if ([type isEqualToString:kCMISPropertyObjectTypeIdValueFolder])
+        {
+            cmisTypeId = kCMISPropertyObjectTypeIdValueFolder;
+        }
+        else
+        {
+            // custom type so prefix appropriately
+            NSString *customTypePrefix = (folder) ? kAlfrescoCMISFolderTypePrefix : kAlfrescoCMISDocumentTypePrefix;
+            cmisTypeId = [customTypePrefix stringByAppendingString:type];
+        }
+    }
+    else
+    {
+        // check the objectTypeId property
+        NSString *providedObjectTypeId = alfrescoProperties[kCMISPropertyObjectTypeId];
+        if (providedObjectTypeId == nil)
+        {
+            if (folder)
+            {
+                cmisTypeId = kCMISPropertyObjectTypeIdValueFolder;
+            }
+            else
+            {
+                cmisTypeId = kCMISPropertyObjectTypeIdValueDocument;
+            }
+        }
+        else
+        {
+            // swap any use of the Alfresco base types with the CMIS equivalent
+            if ([providedObjectTypeId rangeOfString:kAlfrescoContentModelTypeFolder].location != NSNotFound)
+            {
+                cmisTypeId = [providedObjectTypeId stringByReplacingOccurrencesOfString:kAlfrescoContentModelTypeFolder withString:kCMISPropertyObjectTypeIdValueFolder];
+            }
+            else if ([providedObjectTypeId rangeOfString:kAlfrescoContentModelTypeContent].location != NSNotFound)
+            {
+                cmisTypeId = [providedObjectTypeId stringByReplacingOccurrencesOfString:kAlfrescoContentModelTypeContent withString:kCMISPropertyObjectTypeIdValueDocument];
+            }
+            else
+            {
+                // use the provided objectTypeId property
+                cmisTypeId = providedObjectTypeId;
+            }
+        }
+    }
+    
+    // create initial objectTypeId string
+    NSMutableString *objectTypeId = [NSMutableString stringWithString:cmisTypeId];
+    
+    // process aspects
+    NSMutableArray *aspectsToAdd = [NSMutableArray arrayWithArray:aspects];
+    
+    // go through the properties looking for well known aspect properties
+    // whilst the list is small look for them individually, once the list is longer we'll loop
+    if (alfrescoProperties != nil)
+    {
+        // titled aspect
+        if (alfrescoProperties[kAlfrescoContentModelPropertyTitle] != nil ||
+            alfrescoProperties[kAlfrescoContentModelPropertyDescription] != nil)
+        {
+            if (![aspectsToAdd containsObject:kAlfrescoContentModelAspectTitled])
+            {
+                [aspectsToAdd addObject:kAlfrescoContentModelAspectTitled];
+            }
+        }
+        
+        // author aspect
+        if (alfrescoProperties[kAlfrescoContentModelPropertyAuthor] != nil)
+        {
+            if (![aspectsToAdd containsObject:kAlfrescoContentModelAspectAuthor])
+            {
+                [aspectsToAdd addObject:kAlfrescoContentModelAspectAuthor];
+            }
+        }
+        
+        // geogrpahic aspect
+        if (alfrescoProperties[kAlfrescoContentModelPropertyLatitude] != nil ||
+            alfrescoProperties[kAlfrescoContentModelPropertyLongitude] != nil)
+        {
+            if (![aspectsToAdd containsObject:kAlfrescoContentModelAspectGeographic])
+            {
+                [aspectsToAdd addObject:kAlfrescoContentModelAspectGeographic];
+            }
+        }
+    }
+    
+    // append aspects, if required
+    if (aspectsToAdd.count > 0)
+    {
+        [aspectsToAdd enumerateObjectsUsingBlock:^(NSString *aspect, NSUInteger index, BOOL *stop){
+            // ignore any system aspects
+            if (![aspect hasPrefix:kAlfrescoSystemModelPrefix])
+            {
+                // append the aspect if it wasn't already present in the objectTypeId property
+                if ([cmisTypeId rangeOfString:aspect].location == NSNotFound)
+                {
+                    [objectTypeId appendString:[NSString stringWithFormat:@",%@%@", kAlfrescoCMISAspectPrefix, aspect]];
+                }
+            }
+        }];
+    }
+    
+    return objectTypeId;
+}
+
++ (void)preparePropertiesForUpdate:(NSDictionary *)alfrescoProperties
+                              node:(AlfrescoNode *)node
+                       cmisSession:(CMISSession *)cmisSession
+                   completionBlock:(void (^)(CMISProperties *cmisProperties, NSError *error))completionBlock
+{
+    // swap the cm:name for cmis:name, if present
+    NSMutableDictionary *cmisProperties = [NSMutableDictionary dictionaryWithDictionary:alfrescoProperties];
+    if ([[alfrescoProperties allKeys] containsObject:kAlfrescoContentModelPropertyName])
+    {
+        NSString *name = [alfrescoProperties valueForKey:kAlfrescoContentModelPropertyName];
+        [cmisProperties setValue:name forKey:kCMISPropertyName];
+        [cmisProperties removeObjectForKey:kAlfrescoContentModelPropertyName];
+    }
+    
+    // make sure there is a cmis:name property present
+    if (![[cmisProperties allKeys] containsObject:kCMISPropertyName])
+    {
+        [cmisProperties setValue:node.name forKey:kCMISPropertyName];
+    }
+    
+    // set the fully qualified objectTypeId
+    NSString *objectTypeId = [AlfrescoCMISUtil prepareObjectTypeIdForProperties:alfrescoProperties type:node.type aspects:node.aspects folder:node.isFolder];
+    [cmisProperties setValue:objectTypeId forKey:kCMISPropertyObjectTypeId];
+    
+    // TODO: determine if we really need to re-retrieve the object
+    [cmisSession retrieveObject:node.identifier completionBlock:^(CMISObject *cmisObject, NSError *error) {
+        if (nil == cmisObject)
+        {
+            NSError *alfrescoError = [AlfrescoCMISUtil alfrescoErrorWithCMISError:error];
+            completionBlock(nil, alfrescoError);
+        }
+        else
+        {
+            // get the CMIS session to convert the raw dictionary into a CMISProperties object, this will
+            // also call our overridden converter in order to build extension data representing aspects.
+            [cmisSession.objectConverter convertProperties:cmisProperties
+                                           forObjectTypeId:cmisObject.objectType
+                                           completionBlock:^(CMISProperties *convertedProperties, NSError *conversionError){
+                 if (nil == convertedProperties)
+                 {
+                     NSError *alfrescoError = [AlfrescoCMISUtil alfrescoErrorWithCMISError:conversionError];
+                     completionBlock(nil, alfrescoError);
+                 }
+                 else
+                 {
+                     // re-build dictionary just to remove the objectTypeId property, CMISProperties should provide a remove method!
+                     CMISProperties *updatedProperties = [[CMISProperties alloc] init];
+                     NSEnumerator *enumerator = [convertedProperties.propertiesDictionary keyEnumerator];
+                     for (NSString *cmisKey in enumerator)
+                     {
+                         if (![cmisKey isEqualToString:kCMISPropertyObjectTypeId])
+                         {
+                             CMISPropertyData *propData = (convertedProperties.propertiesDictionary)[cmisKey];
+                             [updatedProperties addProperty:propData];
+                         }
+                     }
+                     updatedProperties.extensions = convertedProperties.extensions;
+                     
+                     // return the properties
+                     completionBlock(updatedProperties, nil);
+                 }
+             }];
+        }
+    }];
+}
 
 @end


### PR DESCRIPTION
MOBSDK-683: Change the way the repository handles the mandatory aspect part of the model

I've renamed and made several content model constants public and renamed some other CMIS related constants.

Also pulled out the property and objectTypeId processing into helper methods so it's in one place and can be used by document folder and versioning services.
