### PR TITLE
Fixed failing test on Cloud

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.h
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.h
@@ -100,6 +100,7 @@ extern NSString * const kAlfrescoSortByDescription;
 extern NSString * const kAlfrescoFilterByWorkflowState;
 extern NSString * const kAlfrescoFilterValueWorkflowStateActive;
 extern NSString * const kAlfrescoFilterValueWorkflowStateCompleted;
+extern NSString * const kAlfrescoFilterValueWorkflowStateAny;
 
 /**---------------------------------------------------------------------------------------
  * @name capability constants

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.m
@@ -57,6 +57,7 @@ NSString * const kAlfrescoSortByDescription = @"description";
 NSString * const kAlfrescoFilterByWorkflowState = @"state";
 NSString * const kAlfrescoFilterValueWorkflowStateActive = @"active";
 NSString * const kAlfrescoFilterValueWorkflowStateCompleted = @"completed";
+NSString * const kAlfrescoFilterValueWorkflowStateAny = @"any";
 
 /**
  Capabilities constants

--- a/AlfrescoSDK/AlfrescoSDK/Services/LegacyAPIServices/AlfrescoLegacyAPIWorkflowService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/LegacyAPIServices/AlfrescoLegacyAPIWorkflowService.m
@@ -183,7 +183,7 @@
 - (AlfrescoRequest *)retrieveProcessesWithListingContext:(AlfrescoListingContext *)listingContext
                                          completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
-    NSString *state = kAlfrescoWorkflowProcessStateAny;
+    NSString *state = kAlfrescoWorkflowProcessStateActive;
     
     // for now map the new filter listing to the existing state constants (now internal) but these should be removed soon
     if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState])
@@ -192,9 +192,9 @@
         {
             state = kAlfrescoWorkflowProcessStateCompleted;
         }
-        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateActive])
+        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateAny])
         {
-            state = kAlfrescoWorkflowProcessStateActive;
+            state = kAlfrescoWorkflowProcessStateAny;
         }
     }
     

--- a/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPIWorkflowService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPIWorkflowService.m
@@ -179,7 +179,7 @@
 - (AlfrescoRequest *)retrieveProcessesWithListingContext:(AlfrescoListingContext *)listingContext
                                          completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
-    NSString *state = kAlfrescoWorkflowProcessStateAny;
+    NSString *state = kAlfrescoWorkflowProcessStateActive;
     
     // for now map the new filter listing to the existing state constants (now internal) but these should be removed soon
     if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState])
@@ -188,9 +188,9 @@
         {
             state = kAlfrescoWorkflowProcessStateCompleted;
         }
-        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateActive])
+        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateAny])
         {
-            state = kAlfrescoWorkflowProcessStateActive;
+            state = kAlfrescoWorkflowProcessStateAny;
         }
     }
     


### PR DESCRIPTION
The default behaviour of the retrieveAllProcesses method should match the default behaviour of the REST API i.e. only return active processes, if all processes (active and completed) are required the new public constant can be used.
