### PR TITLE
Caching fixes and MOBSDK-709

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Services/LegacyAPIServices/AlfrescoLegacyAPISiteService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/LegacyAPIServices/AlfrescoLegacyAPISiteService.m
@@ -72,7 +72,7 @@
         }
         else
         {
-            self.siteCache = [[AlfrescoSiteCache alloc] initWithSiteCacheDataDelegate:self];
+            self.siteCache = [AlfrescoSiteCache new];
             [self.session setObject:self.siteCache forParameter:kAlfrescoSessionCacheSites];
             AlfrescoLogDebug(@"Created new SiteCache object");
         }
@@ -108,7 +108,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 AlfrescoRequest *fetchRequest = [weakSelf fetchAllSitesWithListingContext:(AlfrescoListingContext *)listingContext completionBlock:completionBlock];
@@ -150,7 +150,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 NSArray *sortedSites = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.siteCache.memberSites
@@ -201,7 +201,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 NSArray *sortedSites = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.siteCache.favoriteSites
@@ -239,7 +239,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 // now the cache is built see if we have already retrieved it
@@ -466,7 +466,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 NSArray *sortedSites = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.siteCache.pendingSites

--- a/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPIDocumentFolderService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPIDocumentFolderService.m
@@ -59,7 +59,7 @@
         }
         else
         {
-            self.favoritesCache = [[AlfrescoFavoritesCache alloc] initWithFavoritesCacheDataDelegate:self];
+            self.favoritesCache = [AlfrescoFavoritesCache new];
             [self.session setObject:self.favoritesCache forParameter:kAlfrescoSessionCacheFavorites];
             AlfrescoLogDebug(@"Created new FavoritesCache object");
         }
@@ -240,10 +240,12 @@
     if (!self.favoritesCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.favoritesCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.favoritesCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
-                AlfrescoPagingResult *pagingResult = [AlfrescoPagingUtils pagedResultFromArray:weakSelf.favoritesCache.favoriteDocuments
+                NSArray *sortedFavoriteDocuments = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.favoritesCache.favoriteDocuments
+                                                                                     sortKey:self.defaultSortKey ascending:YES];
+                AlfrescoPagingResult *pagingResult = [AlfrescoPagingUtils pagedResultFromArray:sortedFavoriteDocuments
                                                                                 listingContext:listingContext];
                 completionBlock(pagingResult, nil);
             }
@@ -286,10 +288,12 @@
     if (!self.favoritesCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.favoritesCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.favoritesCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
-                AlfrescoPagingResult *pagingResult = [AlfrescoPagingUtils pagedResultFromArray:weakSelf.favoritesCache.favoriteFolders
+                NSArray *sortedFavoriteFolders = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.favoritesCache.favoriteFolders
+                                                                                     sortKey:self.defaultSortKey ascending:YES];
+                AlfrescoPagingResult *pagingResult = [AlfrescoPagingUtils pagedResultFromArray:sortedFavoriteFolders
                                                                                 listingContext:listingContext];
                 completionBlock(pagingResult, nil);
             }
@@ -332,10 +336,12 @@
     if (!self.favoritesCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.favoritesCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.favoritesCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
-                AlfrescoPagingResult *pagingResult = [AlfrescoPagingUtils pagedResultFromArray:weakSelf.favoritesCache.favoriteNodes
+                NSArray *sortedFavoriteNodes = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.favoritesCache.favoriteNodes
+                                                                                   sortKey:self.defaultSortKey ascending:YES];
+                AlfrescoPagingResult *pagingResult = [AlfrescoPagingUtils pagedResultFromArray:sortedFavoriteNodes
                                                                                 listingContext:listingContext];
                 completionBlock(pagingResult, nil);
             }
@@ -368,7 +374,7 @@
     if (!self.favoritesCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.favoritesCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.favoritesCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 favorite = [weakSelf.favoritesCache isNodeFavorited:node];

--- a/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPISiteService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPISiteService.m
@@ -66,7 +66,7 @@
         }
         else
         {
-            self.siteCache = [[AlfrescoSiteCache alloc] initWithSiteCacheDataDelegate:self];
+            self.siteCache = [AlfrescoSiteCache new];
             [self.session setObject:self.siteCache forParameter:kAlfrescoSessionCacheSites];
             AlfrescoLogDebug(@"Created new SiteCache object");
         }
@@ -101,7 +101,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 AlfrescoRequest *fetchRequest = [weakSelf fetchAllSitesWithListingContext:(AlfrescoListingContext *)listingContext completionBlock:completionBlock];
@@ -143,7 +143,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 NSArray *sortedSites = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.siteCache.memberSites
@@ -193,7 +193,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 NSArray *sortedSites = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.siteCache.favoriteSites
@@ -231,7 +231,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 // now the cache is built see if we have already retrieved it
@@ -386,7 +386,7 @@
     if (!self.siteCache.isCacheBuilt)
     {
         __weak typeof(self) weakSelf = self;
-        request = [self.siteCache buildCacheWithCompletionBlock:^(BOOL succeeded, NSError *error) {
+        request = [self.siteCache buildCacheWithDelegate:self completionBlock:^(BOOL succeeded, NSError *error) {
             if (succeeded)
             {
                 NSArray *sortedSites = [AlfrescoSortingUtils sortedArrayForArray:weakSelf.siteCache.pendingSites

--- a/AlfrescoSDK/AlfrescoSDK/Session/OAuth/AlfrescoOAuthHelper.h
+++ b/AlfrescoSDK/AlfrescoSDK/Session/OAuth/AlfrescoOAuthHelper.h
@@ -1,6 +1,6 @@
 /*
  ******************************************************************************
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
  *
  * This file is part of the Alfresco Mobile SDK.
  *
@@ -22,6 +22,8 @@
 #import <Foundation/Foundation.h>
 #import "AlfrescoOAuthLoginViewController.h"
 #import "AlfrescoOAuthLoginDelegate.h"
+#import "AlfrescoRequest.h"
+
 /** The AlfrescoOAuthHelper handles OAuth authentication processes.
  
  Author: Gavin Cornwell (Alfresco), Tijs Rademakers (Alfresco), Peter Schmidt (Alfresco)
@@ -42,17 +44,17 @@
  @param oauthData - the AlfrescoOAuthData. This object must have the api key, secret key and redirect URI set
  @param completionBlock
  */
-- (void)retrieveOAuthDataForAuthorizationCode:(NSString *)authorizationCode
-                                    oauthData:(AlfrescoOAuthData *)oauthData
-                              completionBlock:(AlfrescoOAuthCompletionBlock)completionBlock;
+- (AlfrescoRequest *)retrieveOAuthDataForAuthorizationCode:(NSString *)authorizationCode
+                                                 oauthData:(AlfrescoOAuthData *)oauthData
+                                           completionBlock:(AlfrescoOAuthCompletionBlock)completionBlock;
 
 
 /**
  @param oauthData - the AlfrescoOAuthData, used for refreshing the access token. For that the AlfrescoOAuthData set needs to contain the api key, secret key, refresh token, and current access token 
  @param completionBlock
  */
-- (void)refreshAccessToken:(AlfrescoOAuthData *)oauthData
-           completionBlock:(AlfrescoOAuthCompletionBlock)completionBlock;
+- (AlfrescoRequest *)refreshAccessToken:(AlfrescoOAuthData *)oauthData
+                        completionBlock:(AlfrescoOAuthCompletionBlock)completionBlock;
 
 
 

--- a/AlfrescoSDK/AlfrescoSDK/Session/OAuth/AlfrescoOAuthLoginViewController.m
+++ b/AlfrescoSDK/AlfrescoSDK/Session/OAuth/AlfrescoOAuthLoginViewController.m
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
  *
  * This file is part of the Alfresco Mobile SDK.
  *
@@ -214,21 +214,15 @@ static NSString * const kOAuthRequestDenyAction = @"action=Deny";
         [self createActivityView];
     }
     [self.activityIndicator startAnimating];
-        
-    NSMutableString *authURLString = [NSMutableString string];
-    [authURLString appendString:self.baseURL];
-    [authURLString appendString:@"?"];
-    [authURLString appendString:[kAlfrescoOAuthClientID stringByReplacingOccurrencesOfString:kAlfrescoClientID withString:self.oauthData.apiKey]];
-    [authURLString appendString:@"&"];
-    [authURLString appendString:[kAlfrescoOAuthRedirectURI stringByReplacingOccurrencesOfString:kAlfrescoRedirectURI withString:self.oauthData.redirectURI]];
-    [authURLString appendString:@"&"];
-    [authURLString appendString:kAlfrescoOAuthScope];
-    [authURLString appendString:@"&"];
-    [authURLString appendString:kAlfrescoOAuthResponseType];
+
+    NSString *authURLString = [NSString stringWithFormat:@"%@?%@&%@&%@&%@", self.baseURL,
+                               [kAlfrescoOAuthClientID stringByReplacingOccurrencesOfString:kAlfrescoClientID withString:self.oauthData.apiKey],
+                               [kAlfrescoOAuthRedirectURI stringByReplacingOccurrencesOfString:kAlfrescoRedirectURI withString:self.oauthData.redirectURI],
+                               kAlfrescoOAuthScope, kAlfrescoOAuthResponseType];
     
     // load the authorization URL in the web view
     NSURL *authURL = [NSURL URLWithString:authURLString];
-    AlfrescoLogDebug(@"UIWebviewDelegate loadWebView: just before loading request with %@",authURLString);
+    AlfrescoLogDebug(@"Loading webview with baseURL", self.baseURL);
     [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
 }
 

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoFavoritesCache.h
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoFavoritesCache.h
@@ -21,14 +21,6 @@
 #import <Foundation/Foundation.h>
 #import "AlfrescoSession.h"
 
-typedef NS_ENUM(NSInteger, AlfrescoFavoriteType)
-{
-    AlfrescoFavoriteDocument = 0,
-    AlfrescoFavoriteFolder,
-    AlfrescoFavoriteNode,
-    
-};
-
 @protocol AlfrescoFavoritesCacheDataDelegate <NSObject>
 - (AlfrescoRequest *)retrieveFavoriteNodeDataWithCompletionBlock:(AlfrescoArrayCompletionBlock)completionBlock;
 @end
@@ -41,14 +33,9 @@ typedef NS_ENUM(NSInteger, AlfrescoFavoriteType)
 @property (nonatomic, strong, readonly) NSArray *favoriteFolders;
 
 /**
- initialiser.
- */
-- (instancetype)initWithFavoritesCacheDataDelegate:(id<AlfrescoFavoritesCacheDataDelegate>)favoritesCacheDataDelegate;
-
-/**
  Build the cache.
  */
-- (AlfrescoRequest *)buildCacheWithCompletionBlock:(AlfrescoBOOLCompletionBlock)completionBlock;
+- (AlfrescoRequest *)buildCacheWithDelegate:(id<AlfrescoFavoritesCacheDataDelegate>)delegate completionBlock:(AlfrescoBOOLCompletionBlock)completionBlock;
 
 /**
  Caches the given node with given flag. If the node already exists in the cache it's favortie state

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoFavoritesCache.m
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoFavoritesCache.m
@@ -47,20 +47,17 @@
 @property (nonatomic, strong, readwrite) NSArray *favoriteNodes;
 @property (nonatomic, strong, readwrite) NSArray *favoriteDocuments;
 @property (nonatomic, strong, readwrite) NSArray *favoriteFolders;
-
-@property (nonatomic, strong) id<AlfrescoFavoritesCacheDataDelegate> delegate;
 @property (nonatomic, strong) NSMutableDictionary *internalFavoritesCache;
 @end
 
 @implementation AlfrescoFavoritesCache
 
-- (instancetype)initWithFavoritesCacheDataDelegate:(id<AlfrescoFavoritesCacheDataDelegate>)favoritesCacheDataDelegate;
+- (instancetype)init
 {
     self = [super init];
     if (nil != self)
     {
         self.isCacheBuilt = NO;
-        self.delegate = favoritesCacheDataDelegate;
         self.internalFavoritesCache = [NSMutableDictionary dictionary];
     }
     return self;
@@ -75,14 +72,14 @@
     [self.internalFavoritesCache removeAllObjects];
 }
 
-- (AlfrescoRequest *)buildCacheWithCompletionBlock:(AlfrescoBOOLCompletionBlock)completionBlock
+- (AlfrescoRequest *)buildCacheWithDelegate:(id<AlfrescoFavoritesCacheDataDelegate>)delegate completionBlock:(AlfrescoBOOLCompletionBlock)completionBlock;
 {
     AlfrescoLogDebug(@"Building favorites cache");
     
     // request the data required to build the initial caches
     AlfrescoLogDebug(@"Requesting favorite node data from delegate");
     AlfrescoRequest *request = [AlfrescoRequest new];
-    request = [self.delegate retrieveFavoriteNodeDataWithCompletionBlock:^(NSArray *array, NSError *error) {
+    request = [delegate retrieveFavoriteNodeDataWithCompletionBlock:^(NSArray *array, NSError *error) {
         if (array != nil)
         {
             // add each node to the cache

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoSiteCache.h
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoSiteCache.h
@@ -36,9 +36,7 @@
 @property (nonatomic, strong, readonly) NSArray *favoriteSites;
 @property (nonatomic, strong, readonly) NSArray *pendingSites;
 
-- (instancetype)initWithSiteCacheDataDelegate:(id<AlfrescoSiteCacheDataDelegate>)siteCacheDataDelegate;
-
-- (AlfrescoRequest *)buildCacheWithCompletionBlock:(AlfrescoBOOLCompletionBlock)completionBlock;
+- (AlfrescoRequest *)buildCacheWithDelegate:(id<AlfrescoSiteCacheDataDelegate>)delegate completionBlock:(AlfrescoBOOLCompletionBlock)completionBlock;
 
 - (void)cacheSite:(AlfrescoSite *)site;
 


### PR DESCRIPTION
Added back sorting of favourite nodes, cache building delegate is now passed as method parameter rather than property via initialiser to fix memory leak and fixed MOBSDK-709 (also removed debug statements that could reveal API key and secret)
