### PR TITLE
MOBSDK-726

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.h
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.h
@@ -97,7 +97,7 @@ extern NSString * const kAlfrescoSortByDescription;
 /**---------------------------------------------------------------------------------------
  * @name filter properties
  --------------------------------------------------------------------------------------- */
-extern NSString * const kAlfrescoFilterByWorkflowState;
+extern NSString * const kAlfrescoFilterByWorkflowStatus;
 extern NSString * const kAlfrescoFilterValueWorkflowStateActive;
 extern NSString * const kAlfrescoFilterValueWorkflowStateCompleted;
 extern NSString * const kAlfrescoFilterValueWorkflowStateAny;

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoConstants.m
@@ -54,7 +54,7 @@ NSString * const kAlfrescoSortByDescription = @"description";
 /**
  Filtering constants
  */
-NSString * const kAlfrescoFilterByWorkflowState = @"state";
+NSString * const kAlfrescoFilterByWorkflowStatus = @"status";
 NSString * const kAlfrescoFilterValueWorkflowStateActive = @"active";
 NSString * const kAlfrescoFilterValueWorkflowStateCompleted = @"completed";
 NSString * const kAlfrescoFilterValueWorkflowStateAny = @"any";

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoWorkflowInternalConstants.h
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoWorkflowInternalConstants.h
@@ -140,7 +140,7 @@ extern NSString * const kAlfrescoWorkflowLegacyJSONBPMPackageContainer;
 
 extern NSString * const kAlfrescoWorkflowLegacyJSONOwner;
 
-extern NSString * const kAlfrescoWorkflowPublicBPMJSONProcessTitle;
+extern NSString * const kAlfrescoWorkflowPublicBPMJSONProcessDescription;
 extern NSString * const kAlfrescoWorkflowPublicBPMJSONProcessAssignee;
 extern NSString * const kAlfrescoWorkflowPublicBPMJSONProcessAssignees;
 

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoWorkflowInternalConstants.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoWorkflowInternalConstants.m
@@ -140,7 +140,7 @@ NSString * const kAlfrescoWorkflowLegacyJSONBPMPackageContainer = @"bpm_package"
 
 NSString * const kAlfrescoWorkflowLegacyJSONOwner = @"cm_owner";
 
-NSString * const kAlfrescoWorkflowPublicBPMJSONProcessTitle = @"bpm_description";
+NSString * const kAlfrescoWorkflowPublicBPMJSONProcessDescription = @"bpm_description";
 NSString * const kAlfrescoWorkflowPublicBPMJSONProcessAssignee = @"bpm_assignee";
 NSString * const kAlfrescoWorkflowPublicBPMJSONProcessAssignees = @"bpm_assignees";
 

--- a/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoWorkflowProcess.m
+++ b/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoWorkflowProcess.m
@@ -85,7 +85,6 @@ static NSInteger kWorkflowProcessModelVersion = 1;
         }
         self.startedAt = [self.dateFormatter dateFromString:entry[kAlfrescoWorkflowPublicJSONStartedAt]];
         self.endedAt = [self.dateFormatter dateFromString:entry[kAlfrescoWorkflowPublicJSONEndedAt]];
-        self.summary = entry[kAlfrescoWorkflowPublicJSONDescription];
         self.initiatorUsername = entry[kAlfrescoWorkflowPublicJSONStartUserID];
         self.variables = convertedVariables;
     }
@@ -96,7 +95,7 @@ static NSInteger kWorkflowProcessModelVersion = 1;
         self.processDefinitionKey = properties[kAlfrescoWorkflowLegacyJSONName];
         if (properties[kAlfrescoWorkflowLegacyJSONMessage] != [NSNull null])
         {
-            self.name = properties[kAlfrescoWorkflowLegacyJSONMessage];
+            self.summary = properties[kAlfrescoWorkflowLegacyJSONMessage];
         }
         if (properties[kAlfrescoWorkflowLegacyJSONStartedAt] != [NSNull null])
         {
@@ -110,7 +109,7 @@ static NSInteger kWorkflowProcessModelVersion = 1;
         {
             self.dueAt = [self.dateFormatter dateFromString:properties[kAlfrescoWorkflowLegacyJSONDueAt]];
         }
-        self.summary = properties[kAlfrescoWorkflowLegacyJSONDescription];
+        self.name = properties[kAlfrescoWorkflowLegacyJSONTitle];
         self.priority = properties[kAlfrescoWorkflowLegacyJSONPriority];
         NSDictionary *initiatorDictionary = properties[kAlfrescoWorkflowLegacyJSONInitiator];
         self.initiatorUsername = initiatorDictionary[kAlfrescoJSONUserName];
@@ -124,7 +123,7 @@ static NSInteger kWorkflowProcessModelVersion = 1;
     [aCoder encodeObject:self.identifier forKey:kAlfrescoWorkflowPublicJSONIdentifier];
     [aCoder encodeObject:self.processDefinitionIdentifier forKey:kAlfrescoWorkflowPublicJSONProcessDefinitionID];
     [aCoder encodeObject:self.processDefinitionKey forKey:kAlfrescoWorkflowPublicJSONProcessDefinitionKey];
-    [aCoder encodeObject:self.name forKey:kAlfrescoWorkflowPublicBPMJSONProcessTitle];
+    [aCoder encodeObject:self.name forKey:kAlfrescoWorkflowPublicBPMJSONProcessDescription];
     [aCoder encodeObject:self.startedAt forKey:kAlfrescoWorkflowPublicJSONStartedAt];
     [aCoder encodeObject:self.endedAt forKey:kAlfrescoWorkflowPublicJSONEndedAt];
     [aCoder encodeObject:self.dueAt forKey:kAlfrescoWorkflowPublicJSONDueAt];
@@ -143,7 +142,7 @@ static NSInteger kWorkflowProcessModelVersion = 1;
         self.identifier = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicJSONIdentifier];
         self.processDefinitionIdentifier = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicJSONProcessDefinitionID];
         self.processDefinitionKey = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicJSONProcessDefinitionKey];
-        self.name = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicBPMJSONProcessTitle];
+        self.name = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicBPMJSONProcessDescription];
         self.startedAt = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicJSONStartedAt];
         self.endedAt = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicJSONEndedAt];
         self.dueAt = [aDecoder decodeObjectForKey:kAlfrescoWorkflowPublicJSONDueAt];
@@ -171,10 +170,10 @@ static NSInteger kWorkflowProcessModelVersion = 1;
 
 - (void)setPropertiesFromVariables:(NSDictionary *)variables
 {
-    AlfrescoProperty *titleVariable = variables[kAlfrescoWorkflowPublicBPMJSONProcessTitle];
+    AlfrescoProperty *titleVariable = variables[kAlfrescoWorkflowPublicBPMJSONProcessDescription];
     if (titleVariable.value != [NSNull null])
     {
-        self.name = (NSString *)titleVariable.value;
+        self.summary = (NSString *)titleVariable.value;
     }
     
     AlfrescoProperty *priorityVariable = variables[kAlfrescoWorkflowVariableProcessPriority];

--- a/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoWorkflowTask.m
+++ b/AlfrescoSDK/AlfrescoSDK/Model/AlfrescoWorkflowTask.m
@@ -69,12 +69,12 @@ static NSInteger kWorkflowTaskModelVersion = 1;
         self.identifier = entry[kAlfrescoWorkflowPublicJSONIdentifier];
         self.processIdentifier = entry[kAlfrescoWorkflowPublicJSONProcessID];
         self.processDefinitionIdentifier = entry[kAlfrescoWorkflowPublicJSONProcessDefinitionID];
-        self.name = entry[kAlfrescoWorkflowPublicJSONDescription];
+        self.summary = entry[kAlfrescoWorkflowPublicJSONDescription];
         self.type = entry[kAlfrescoWorkflowPublicJSONFormResourceKey];
         self.startedAt = [self.dateFormatter dateFromString:entry[kAlfrescoWorkflowPublicJSONStartedAt]];
         self.endedAt = [self.dateFormatter dateFromString:entry[kAlfrescoWorkflowPublicJSONEndedAt]];
         self.dueAt = [self.dateFormatter dateFromString:entry[kAlfrescoWorkflowPublicJSONDueAt]];
-        self.summary = entry[kAlfrescoWorkflowPublicJSONName];
+        self.name = entry[kAlfrescoWorkflowPublicJSONName];
         self.priority = entry[kAlfrescoWorkflowPublicJSONPriority];
         self.assigneeIdentifier = entry[kAlfrescoWorkflowPublicJSONAssignee];
     }
@@ -86,7 +86,7 @@ static NSInteger kWorkflowTaskModelVersion = 1;
         self.identifier = properties[kAlfrescoWorkflowLegacyJSONIdentifier];
         self.processIdentifier = workflowInstance[kAlfrescoWorkflowLegacyJSONIdentifier];
         self.processDefinitionIdentifier = workflowInstance[kAlfrescoWorkflowLegacyJSONName];
-        self.name = taskProperties[kAlfrescoWorkflowLegacyJSONBPMDescription];
+        self.name = properties[kAlfrescoWorkflowLegacyJSONTitle];
         self.type = properties[kAlfrescoWorkflowLegacyJSONName];
         if (taskProperties[kAlfrescoWorkflowLegacyJSONBPMStartedAt] != [NSNull null])
         {
@@ -100,7 +100,7 @@ static NSInteger kWorkflowTaskModelVersion = 1;
         {
             self.dueAt = [self.dateFormatter dateFromString:taskProperties[kAlfrescoWorkflowLegacyJSONBPMDueAt]];
         }
-        self.summary = properties[kAlfrescoWorkflowLegacyJSONDescription];
+        self.summary = taskProperties[kAlfrescoWorkflowLegacyJSONBPMDescription];
         self.priority = taskProperties[kAlfrescoWorkflowLegacyJSONBPMPriority];
         if (taskProperties[kAlfrescoWorkflowLegacyJSONOwner] != [NSNull null])
         {

--- a/AlfrescoSDK/AlfrescoSDK/Services/LegacyAPIServices/AlfrescoLegacyAPIWorkflowService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/LegacyAPIServices/AlfrescoLegacyAPIWorkflowService.m
@@ -185,9 +185,9 @@
     NSString *requestString = [kAlfrescoLegacyAPIWorkflowInstances stringByReplacingOccurrencesOfString:kAlfrescoPersonId withString:self.session.personIdentifier];
     
     // for now map the new filter listing to the existing state constants (now internal) but these should be removed soon
-    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState])
+    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowStatus])
     {
-        NSString *requestedState = [listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState];
+        NSString *requestedState = [listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus];
         
         if (![requestedState isEqualToString:kAlfrescoFilterValueWorkflowStateAny])
         {
@@ -349,9 +349,9 @@
     
     NSString *stateParameterValue = kAlfrescoLegacyAPIWorkflowStatusInProgress;
     
-    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState])
+    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowStatus])
     {
-        NSString *requestedState = [listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState];
+        NSString *requestedState = [listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus];
         
         if ([requestedState isEqualToString:kAlfrescoFilterValueWorkflowStateCompleted])
         {

--- a/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPIWorkflowService.m
+++ b/AlfrescoSDK/AlfrescoSDK/Services/PublicAPIServices/AlfrescoPublicAPIWorkflowService.m
@@ -169,21 +169,21 @@
 - (AlfrescoRequest *)retrieveProcessesWithListingContext:(AlfrescoListingContext *)listingContext
                                          completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
-    NSString *stateParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusActive;
+    NSString *statusParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusActive;
     
-    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState])
+    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowStatus])
     {
-        if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateCompleted])
+        if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus] isEqualToString:kAlfrescoFilterValueWorkflowStateCompleted])
         {
-            stateParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusCompleted;
+            statusParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusCompleted;
         }
-        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateAny])
+        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus] isEqualToString:kAlfrescoFilterValueWorkflowStateAny])
         {
-            stateParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusAny;
+            statusParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusAny;
         }
     }
     
-    return [self retrieveProcessesInState:stateParameterValue listingContext:listingContext completionBlock:completionBlock];
+    return [self retrieveProcessesWithStatus:statusParameterValue listingContext:listingContext completionBlock:completionBlock];
 }
 
 - (AlfrescoRequest *)retrieveProcessWithIdentifier:(NSString *)processIdentifier
@@ -289,21 +289,21 @@
     [AlfrescoErrors assertArgumentNotNil:process argumentName:@"process"];
     [AlfrescoErrors assertArgumentNotNil:completionBlock argumentName:@"completionBlock"];
     
-    NSString *stateParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusAny;
+    NSString *statusParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusAny;
     
-    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState])
+    if ([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowStatus])
     {
-        if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateCompleted])
+        if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus] isEqualToString:kAlfrescoFilterValueWorkflowStateCompleted])
         {
-            stateParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusCompleted;
+            statusParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusCompleted;
         }
-        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateActive])
+        else if ([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus] isEqualToString:kAlfrescoFilterValueWorkflowStateActive])
         {
-            stateParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusActive;
+            statusParameterValue = kAlfrescoPublicAPIWorkflowProcessStatusActive;
         }
     }
     
-    NSString *queryString = [AlfrescoURLUtils buildQueryStringWithDictionary:@{kAlfrescoWorkflowTaskState : stateParameterValue}];
+    NSString *queryString = [AlfrescoURLUtils buildQueryStringWithDictionary:@{kAlfrescoPublicAPIWorkflowProcessStatus : statusParameterValue}];
     NSString *requestString = [kAlfrescoPublicAPIWorkflowTasksForProcess stringByReplacingOccurrencesOfString:kAlfrescoProcessID withString:process.identifier];
     NSString *completeRequestString = [requestString stringByAppendingString:queryString];
     
@@ -939,17 +939,15 @@
     return request;
 }
 
-- (AlfrescoRequest *)fallbackRetrieveProcessesInState:(NSString *)state listingContext:(AlfrescoListingContext *)listingContext completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
+- (AlfrescoRequest *)fallbackretrieveProcessesWithStatus:(NSString *)status listingContext:(AlfrescoListingContext *)listingContext completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
     [AlfrescoErrors assertArgumentNotNil:completionBlock argumentName:@"completionBlock"];
     [AlfrescoErrors assertArgumentNotNil:listingContext argumentName:@"listingContext"];
     
     // Attempt to get all processes without variables
-    NSString *whereParameterString = [NSString stringWithFormat:@"(%@=%@)", kAlfrescoPublicAPIWorkflowProcessStatus, state];
-    
+    NSString *whereParameterString = [NSString stringWithFormat:@"(%@=%@)", kAlfrescoPublicAPIWorkflowProcessStatus, status];
     NSString *queryString = [AlfrescoURLUtils buildQueryStringWithDictionary:@{kAlfrescoPublicAPIWorkflowProcessWhereParameter : whereParameterString}];
     NSString *extensionURLString = [kAlfrescoPublicAPIWorkflowProcesses stringByAppendingString:queryString];
-    
     NSURL *url = [AlfrescoURLUtils buildURLFromBaseURLString:self.baseApiUrl extensionURL:extensionURLString listingContext:listingContext];
     
     AlfrescoRequest *request = [[AlfrescoRequest alloc] init];
@@ -1031,9 +1029,7 @@
     return request;
 }
 
-- (AlfrescoRequest *)retrieveProcessesInState:(NSString *)state
-                               listingContext:(AlfrescoListingContext *)listingContext
-                              completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
+- (AlfrescoRequest *)retrieveProcessesWithStatus:(NSString *)status listingContext:(AlfrescoListingContext *)listingContext completionBlock:(AlfrescoPagingResultCompletionBlock)completionBlock
 {
     [AlfrescoErrors assertArgumentNotNil:completionBlock argumentName:@"completionBlock"];
     
@@ -1043,7 +1039,7 @@
     }
     
     NSString *whereParameterString = [NSString stringWithFormat:@"(%@=%@ AND %@=%@)",
-                                      kAlfrescoPublicAPIWorkflowProcessStatus, state,
+                                      kAlfrescoPublicAPIWorkflowProcessStatus, status,
                                       kAlfrescoPublicAPIWorkflowProcessIncludeVariables, @"true"];
     
     NSString *queryString = [AlfrescoURLUtils buildQueryStringWithDictionary:@{kAlfrescoPublicAPIWorkflowProcessWhereParameter : whereParameterString}];
@@ -1059,7 +1055,7 @@
             // As a result, we use a slower and network heavy fallback mechanism which first retrieves the processes and then the variables for each process.
             if (error.code == kAlfrescoErrorCodeHTTPResponse)
             {
-                AlfrescoRequest *retrieveRequest = [self fallbackRetrieveProcessesInState:state listingContext:listingContext completionBlock:completionBlock];
+                AlfrescoRequest *retrieveRequest = [self fallbackretrieveProcessesWithStatus:status listingContext:listingContext completionBlock:completionBlock];
                 request.httpRequest = retrieveRequest.httpRequest;
             }
             else

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoBaseTest.h
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoBaseTest.h
@@ -41,6 +41,7 @@
 @property (nonatomic, strong) NSString *unitTestFolder;
 @property (nonatomic, strong) id<AlfrescoSession> currentSession;
 // Test environment parameters
+@property (nonatomic, strong) NSString *userTestConfigFolder;
 @property (nonatomic, strong) NSString *testSearchFileName;
 @property (nonatomic, strong) NSString *testSearchFileKeywords;
 @property (nonatomic, strong) NSString *textKeyWord;
@@ -75,6 +76,5 @@
 - (NSDictionary *)setupEnvironmentParameters;
 - (void)setUpTestImageFile:(NSString *)filePath;
 - (void)resetTestVariables;
-- (NSString *)userTestConfigFolder;
 
 @end

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoDocumentFolderServiceTest.m
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoDocumentFolderServiceTest.m
@@ -1745,7 +1745,7 @@
                      NSMutableArray *myObject = [NSMutableArray array];
                      [myObject addObject:doc];
                      
-                     NSString *filePath = [[self userTestConfigFolder] stringByAppendingPathComponent:@"serialized-object.txt"];
+                     NSString *filePath = [self.userTestConfigFolder stringByAppendingPathComponent:@"serialized-object.txt"];
                      [NSKeyedArchiver archiveRootObject:myObject toFile:filePath];
                      
                      NSMutableArray* myArray = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoUtilsTest.m
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoUtilsTest.m
@@ -60,16 +60,16 @@
                   @"Expected sortProperty to be %@ but it was %@", kAlfrescoSortByTitle, listingContext.sortProperty);
     XCTAssertFalse(listingContext.sortAscending, @"Expected sortAscending to be NO");
     
-    AlfrescoListingFilter *listingFilter = [[AlfrescoListingFilter alloc] initWithFilter:kAlfrescoFilterByWorkflowState value:kAlfrescoFilterValueWorkflowStateActive];
+    AlfrescoListingFilter *listingFilter = [[AlfrescoListingFilter alloc] initWithFilter:kAlfrescoFilterByWorkflowStatus value:kAlfrescoFilterValueWorkflowStateActive];
     listingContext = [[AlfrescoListingContext alloc] initWithListingFilter:listingFilter];
     XCTAssertTrue(listingContext.maxItems == 50, @"Expected maxItems to default to 50");
     XCTAssertTrue(listingContext.skipCount == 0, @"Expected skipCount to default to 0");
     XCTAssertEqual(listingFilter, listingContext.listingFilter, @"Expected the given listing filter to be the one returned from the listing context");
     XCTAssertTrue(listingContext.listingFilter.filters.count == 1,
                   "Expected listingFilter to have 1 filter but it had %lu", (unsigned long)listingContext.listingFilter.filters.count);
-    XCTAssertTrue([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowState], @"Expected the listing filter to have the kAlfrescoFilterByWorkflowState filter");
-    XCTAssertTrue([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState] isEqualToString:kAlfrescoFilterValueWorkflowStateActive],
-                  @"Expected the listing filter value to be kAlfrescoFilterValueWorkflowStateActive but it was %@", [listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowState]);
+    XCTAssertTrue([listingContext.listingFilter hasFilter:kAlfrescoFilterByWorkflowStatus], @"Expected the listing filter to have the kAlfrescoFilterByWorkflowStatus filter");
+    XCTAssertTrue([[listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus] isEqualToString:kAlfrescoFilterValueWorkflowStateActive],
+                  @"Expected the listing filter value to be kAlfrescoFilterValueWorkflowStateActive but it was %@", [listingContext.listingFilter valueForFilter:kAlfrescoFilterByWorkflowStatus]);
     
     // test the properties are readwrite
     listingContext = [AlfrescoListingContext new];

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoWorkflowProcessTests.m
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoWorkflowProcessTests.m
@@ -75,10 +75,10 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                                           process.processDefinitionIdentifier);
                             XCTAssertTrue([process.identifier rangeOfString:@"jbpm$"].location != NSNotFound,
                                           @"Expected identifer to contain jbpm$ but it was %@", process.identifier);
-                            XCTAssertTrue([process.summary isEqualToString:@"Review & approval of content"],
-                                          @"Expected adhoc summary to be 'Review & approval of content' but it was %@", process.summary);
+                            XCTAssertTrue([process.name isEqualToString:@"Review & Approve"],
+                                          @"Expected adhoc summary to be 'Review & Approve' but it was %@", process.summary);
                             
-                            XCTAssertNotNil(process.name, @"Expected name to be populated");
+                            XCTAssertNotNil(process.summary, @"Expected summary to be populated");
                             XCTAssertNotNil(process.startedAt, @"Expected startedAt to be populated");
                             XCTAssertNotNil(process.priority, @"Expected priority to be populated");
                             XCTAssertNotNil(process.initiatorUsername, @"Expected initiatorUsername to be populated");
@@ -121,15 +121,15 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                                 }
                                 
                                 XCTAssertNotNil(process.identifier, @"Expected identifier to be populated");
-                                XCTAssertNotNil(process.name, @"Expected name to be populated");
+                                XCTAssertNotNil(process.summary, @"Expected summary to be populated");
                                 XCTAssertNotNil(process.startedAt, @"Expected startedAt to be populated");
                                 XCTAssertNotNil(process.priority, @"Expected priority to be populated");
                                 XCTAssertNotNil(process.initiatorUsername, @"Expected initiatorUsername to be populated");
                                 XCTAssertNotNil(process.variables, @"Expected variables to be populated");
                                 XCTAssertTrue(process.variables.count > 0, @"Expected variables count to be more than 0");
                                 
-                                // the summary property for the public api will always be nil
-                                XCTAssertNil(process.summary, @"Expected the summary property to be nil when using the public API");
+                                // the name property for the public api will always be nil
+                                XCTAssertNil(process.name, @"Expected the name property to be nil when using the public API");
                                 
                                 reviewProcessFound = YES;
                                 break;
@@ -231,7 +231,7 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
         self.workflowService = [[AlfrescoWorkflowService alloc] initWithSession:self.currentSession];
         
         AlfrescoListingFilter *listingFilter = [[AlfrescoListingFilter alloc]
-                                                initWithFilter:kAlfrescoFilterByWorkflowState value:kAlfrescoFilterValueWorkflowStateActive];
+                                                initWithFilter:kAlfrescoFilterByWorkflowStatus value:kAlfrescoFilterValueWorkflowStateActive];
         AlfrescoListingContext *listingContext = [[AlfrescoListingContext alloc] initWithListingFilter:listingFilter];
         
         [self.workflowService retrieveProcessesWithListingContext:listingContext
@@ -277,7 +277,7 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
         self.workflowService = [[AlfrescoWorkflowService alloc] initWithSession:self.currentSession];
         
         AlfrescoListingFilter *listingFilter = [[AlfrescoListingFilter alloc]
-                                                initWithFilter:kAlfrescoFilterByWorkflowState value:kAlfrescoFilterValueWorkflowStateCompleted];
+                                                initWithFilter:kAlfrescoFilterByWorkflowStatus value:kAlfrescoFilterValueWorkflowStateCompleted];
         AlfrescoListingContext *listingContext = [[AlfrescoListingContext alloc] initWithListingFilter:listingFilter];
         
         [self.workflowService retrieveProcessesWithListingContext:listingContext
@@ -352,7 +352,7 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                         XCTAssertNotNil(process.identifier, @"Expected identifier property to be populated");
                         XCTAssertNotNil(process.processDefinitionKey, @"Expected processDefinitionKey property to be populated");
                         XCTAssertNotNil(process.processDefinitionIdentifier, @"Expected processDefinitionIdentifier property to be populated");
-                        XCTAssertNotNil(process.name, @"Expected name property to be populated");
+                        XCTAssertNotNil(process.summary, @"Expected summary property to be populated");
                         XCTAssertNotNil(process.identifier, @"Expected identifier property to be populated");
                         XCTAssertNotNil(process.startedAt, @"Expected startedAt property to be populated");
                         XCTAssertNotNil(process.priority, @"Expected priority property to be populated");
@@ -367,10 +367,10 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                         XCTAssertTrue([process.processDefinitionKey rangeOfString:@"dhoc"].location != NSNotFound,
                                       @"Expected processDefinitionKey to contain 'dhoc' but it was %@", process.processDefinitionKey);
                         
-                        // the summary property for the public api will always be nil
+                        // the name property for the public api will always be nil
                         if (self.currentSession.repositoryInfo.capabilities.doesSupportPublicAPI)
                         {
-                            XCTAssertNil(process.summary, @"Expected the summary property to be nil when using the public API");
+                            XCTAssertNil(process.name, @"Expected the name property to be nil when using the public API");
                         }
                         else
                         {
@@ -445,7 +445,7 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                 XCTAssertNotNil(createdProcess.identifier, @"Expected identifier property to be populated");
                 XCTAssertNotNil(createdProcess.processDefinitionKey, @"Expected processDefinitionKey property to be populated");
                 XCTAssertNotNil(createdProcess.processDefinitionIdentifier, @"Expected processDefinitionIdentifier property to be populated");
-                XCTAssertNotNil(createdProcess.name, @"Expected name property to be populated");
+                XCTAssertNotNil(createdProcess.summary, @"Expected summary property to be populated");
                 XCTAssertNotNil(createdProcess.identifier, @"Expected identifier property to be populated");
                 XCTAssertNotNil(createdProcess.startedAt, @"Expected startedAt property to be populated");
                 XCTAssertNotNil(createdProcess.priority, @"Expected priority property to be populated");
@@ -459,10 +459,10 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                               @"Expected processDefinitionKey to contain 'dhoc' but it was %@", createdProcess.processDefinitionKey);
                 XCTAssertTrue(createdProcess.variables.count > 0, @"Expected variables count to be more than 0");
                 
-                // the summary property for the public api will always be nil
+                // the name property for the public api will always be nil
                 if (self.currentSession.repositoryInfo.capabilities.doesSupportPublicAPI)
                 {
-                    XCTAssertNil(createdProcess.summary, @"Expected the summary property to be nil when using the public API");
+                    XCTAssertNil(createdProcess.name, @"Expected the name property to be nil when using the public API");
                 }
                 else
                 {
@@ -540,7 +540,7 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                         XCTAssertNotNil(createdProcess.identifier, @"Expected identifier property to be populated");
                         XCTAssertNotNil(createdProcess.processDefinitionKey, @"Expected processDefinitionKey property to be populated");
                         XCTAssertNotNil(createdProcess.processDefinitionIdentifier, @"Expected processDefinitionIdentifier property to be populated");
-                        XCTAssertNotNil(createdProcess.name, @"Expected name property to be populated");
+                        XCTAssertNotNil(createdProcess.summary, @"Expected summary property to be populated");
                         XCTAssertNotNil(createdProcess.identifier, @"Expected identifier property to be populated");
                         XCTAssertNotNil(createdProcess.startedAt, @"Expected startedAt property to be populated");
                         XCTAssertNotNil(createdProcess.priority, @"Expected priority property to be populated");
@@ -553,13 +553,13 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                         XCTAssertTrue([createdProcess.processDefinitionKey rangeOfString:@"dhoc"].location != NSNotFound,
                                       @"Expected processDefinitionKey to contain 'dhoc' but it was %@", createdProcess.processDefinitionKey);
                         XCTAssertTrue(createdProcess.variables.count > 0, @"Expected variables count to be more than 0");
-                        XCTAssertTrue([createdProcess.name isEqualToString:processName], @"The process name should be %@, but got back %@", processName, createdProcess.name);
+                        XCTAssertTrue([createdProcess.summary isEqualToString:processName], @"The process summary should be %@, but got back %@", processName, createdProcess.summary);
                         XCTAssertTrue(createdProcess.priority.intValue == priority.integerValue, @"The priority should be %i, but got back %i", priority.intValue, createdProcess.priority.intValue);
                         
-                        // the summary property for the public api will always be nil
+                        // the name property for the public api will always be nil
                         if (self.currentSession.repositoryInfo.capabilities.doesSupportPublicAPI)
                         {
-                            XCTAssertNil(createdProcess.summary, @"Expected the summary property to be nil when using the public API");
+                            XCTAssertNil(createdProcess.name, @"Expected the name property to be nil when using the public API");
                         }
                         else
                         {

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoWorkflowTaskTests.m
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoWorkflowTaskTests.m
@@ -72,10 +72,10 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                                           @"Expected identifier to contain jbpm$ but it was %@", task.identifier);
                             XCTAssertTrue([task.processIdentifier rangeOfString:kAlfrescoJBPMPrefix].location != NSNotFound,
                                           @"Expected processIdentifier to contain jbpm$ but it was %@", task.processIdentifier);
-                            XCTAssertTrue([task.summary isEqualToString:@"Review Documents to Approve or Reject them"],
-                                          @"Expected task summary to be 'Review Documents to Approve or Reject them' but it was %@", task.summary);
+                            XCTAssertTrue([task.name isEqualToString:@"Review"],
+                                          @"Expected task summary to be 'Review' but it was %@", task.name);
                             
-                            XCTAssertNotNil(task.name, @"Expected the name property to be populated");
+                            XCTAssertNotNil(task.summary, @"Expected the name property to be populated");
                             XCTAssertNotNil(task.type, @"Expected the type property to be populated");
                             XCTAssertNotNil(task.priority, @"Expected the priority property to be populated");
                             XCTAssertNotNil(task.assigneeIdentifier, @"Expected the assigneeIdentifier property to be populated");
@@ -95,8 +95,8 @@ static NSString * const kAlfrescoActivitiParallelReviewProcessDefinitionKey = @"
                             if ((self.isCloud && [task.processDefinitionIdentifier rangeOfString:kAlfrescoActivitiParallelReviewProcessDefinitionKey].location != NSNotFound) ||
                                 (!self.isCloud && [task.processDefinitionIdentifier rangeOfString:kAlfrescoActivitiReviewProcessDefinitionKey].location != NSNotFound))
                             {
-                                XCTAssertTrue([task.summary isEqualToString:@"Review Task"],
-                                              @"Expected task summary to be 'Review Task' but it was %@", task.summary);
+                                XCTAssertTrue([task.name isEqualToString:@"Review Task"],
+                                              @"Expected task name to be 'Review Task' but it was %@", task.name);
                                 
                                 XCTAssertNotNil(task.identifier, @"Expected the identifier property to be populated");
                                 XCTAssertNotNil(task.processIdentifier, @"Expected the processIdentifier property to be populated");


### PR DESCRIPTION
Workflow: Wrong query parameter "state" where it should be "status"
- Also helps fix MOBILE-2812: No information given on tasks that have been approved or rejected
- Fixed test fallout from making task and workflow model properties closer to the Android SDK equivalents
