### PR TITLE
MOBSDK-752: As a developer I can retrieve model definitions for types and aspects using the iOS SDK

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.h
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.h
@@ -98,6 +98,8 @@ extern NSString * const kAlfrescoSessionUsername;
 extern NSString * const kAlfrescoSessionPassword;
 extern NSString * const kAlfrescoSessionCacheSites;
 extern NSString * const kAlfrescoSessionCacheFavorites;
+extern NSString * const kAlfrescoSessionCacheDefinitionType;
+extern NSString * const kAlfrescoSessionCacheDefinitionAspect;
 extern NSString * const kAlfrescoSessionAlternatePersonIdentifier;
 
 extern NSString * const kAlfrescoSiteIsFavorite;

--- a/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.m
+++ b/AlfrescoSDK/AlfrescoSDK/Constants/AlfrescoInternalConstants.m
@@ -115,6 +115,8 @@ NSString * const kAlfrescoSessionUsername = @"org.alfresco.mobile.internal.sessi
 NSString * const kAlfrescoSessionPassword = @"org.alfresco.mobile.internal.session.password";
 NSString * const kAlfrescoSessionCacheSites = @"org.alfresco.mobile.internal.cache.sites";
 NSString * const kAlfrescoSessionCacheFavorites = @"org.alfresco.mobile.internal.cache.favorites";
+NSString * const kAlfrescoSessionCacheDefinitionType = @"org.alfresco.mobile.internal.cache.definition.type";
+NSString * const kAlfrescoSessionCacheDefinitionAspect = @"org.alfresco.mobile.internal.cache.definition.aspect";
 // Temporary for ACE-1445
 NSString * const kAlfrescoSessionAlternatePersonIdentifier = @"org.alfresco.mobile.internal.session.personIdentifier";
 

--- a/AlfrescoSDK/AlfrescoSDK/Model/Definition/AlfrescoModelDefinition.m
+++ b/AlfrescoSDK/AlfrescoSDK/Model/Definition/AlfrescoModelDefinition.m
@@ -80,4 +80,19 @@
     return self.propertyDefinitions[name];
 }
 
+- (void)addPropertyDefinitions:(NSArray *)definitions
+{
+    NSMutableDictionary *updatedPropertyDefinitions = [NSMutableDictionary dictionaryWithDictionary:self.propertyDefinitions];
+    
+    for (AlfrescoPropertyDefinition *propertyDefinition in definitions)
+    {
+        if ([updatedPropertyDefinitions objectForKey:propertyDefinition.name] == nil)
+        {
+            updatedPropertyDefinitions[propertyDefinition.name] = propertyDefinition;
+        }
+    }
+    
+    self.propertyDefinitions = updatedPropertyDefinitions;
+}
+
 @end

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoCMISToAlfrescoObjectConverter.h
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoCMISToAlfrescoObjectConverter.h
@@ -29,6 +29,7 @@
 #import "AlfrescoDocumentTypeDefinition.h"
 #import "AlfrescoFolderTypeDefinition.h"
 #import "AlfrescoAspectDefinition.h"
+#import "AlfrescoTaskTypeDefinition.h"
 
 @class CMISSession, CMISFolder, CMISDocument, CMISObject, CMISObjectData, CMISQueryResult, CMISTypeDefinition;
 
@@ -47,5 +48,7 @@
 - (AlfrescoFolderTypeDefinition *)folderTypeDefinitionFromCMISTypeDefinition:(CMISTypeDefinition *)cmisTypeDefinition;
 
 - (AlfrescoAspectDefinition *)aspectDefinitionFromCMISTypeDefinition:(CMISTypeDefinition *)cmisTypeDefinition;
+
+- (AlfrescoTaskTypeDefinition *)taskTypeDefinitionFromCMISTypeDefinition:(CMISTypeDefinition *)cmisTypeDefinition;
 
 @end

--- a/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoCMISToAlfrescoObjectConverter.m
+++ b/AlfrescoSDK/AlfrescoSDK/Utils/AlfrescoCMISToAlfrescoObjectConverter.m
@@ -278,6 +278,11 @@
     return (AlfrescoAspectDefinition *)[self modelDefinitionFromCMISTypeDefinition:cmisTypeDefinition];
 }
 
+- (AlfrescoTaskTypeDefinition *)taskTypeDefinitionFromCMISTypeDefinition:(CMISTypeDefinition *)cmisTypeDefinition
+{
+    return (AlfrescoTaskTypeDefinition *)[self modelDefinitionFromCMISTypeDefinition:cmisTypeDefinition];
+}
+
 #pragma mark internal methods
 
 - (AlfrescoPropertyType)typeForCMISPropertyTypeString:(NSString *)type


### PR DESCRIPTION
This completes the ModelDefinitionService implementation.
