### PR TITLE
MOBSDK-743: Add networks property to CloudSession

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Session/CloudSession/AlfrescoCloudSession.h
+++ b/AlfrescoSDK/AlfrescoSDK/Session/CloudSession/AlfrescoCloudSession.h
@@ -31,12 +31,16 @@
  */
 
 @interface AlfrescoCloudSession : NSObject <AlfrescoSession>
+
+/// The network this session is connected to.
 @property (nonatomic, strong, readonly) AlfrescoCloudNetwork *network;
+
+/// An array of AlfrescoCloudNetwork objects representing the networks the connected user has access to.
+@property (nonatomic, strong, readonly) NSArray *networks;
 
 /**
  There is a custom setter method of oauthData, which is used for refreshing access tokens. This resets the authentication and CMIS session.
  For initialising a AlfrescoCloudSession, one of the connectWithOAuthData methods must be used.
- @param oauthData
  */
 @property (nonatomic, strong) AlfrescoOAuthData *oauthData;
 

--- a/AlfrescoSDK/AlfrescoSDKTests/AlfrescoSessionTest.m
+++ b/AlfrescoSDK/AlfrescoSDKTests/AlfrescoSessionTest.m
@@ -22,7 +22,8 @@
 #import "AlfrescoLog.h"
 @implementation AlfrescoSessionTest
 
-#pragma mark - AlfrescoRepository Specific Tests
+#pragma mark - On-premise Specific Tests
+
 /*
  @Unique_TCRef 77F8
  */
@@ -64,55 +65,104 @@
 }
 
 #pragma mark - Cloud Specific Tests
+
 /*
  @Unique_TCRef 70S1
  @Unique_TCRef 70S0
  */
 
- // Commented until MOBSDK-543 is resolved
-
-/*
 - (void)testRetrieveNetworks
 {
-    [self runAllSitesTest:^{
-        
+    if (self.setUpSuccess)
+    {
         if (self.isCloud)
         {
-            [(AlfrescoCloudSession *)self.currentSession retrieveNetworksWithCompletionBlock:^(NSArray *array, NSError *error) {
+            AlfrescoCloudSession *cloudSession = (AlfrescoCloudSession *)self.currentSession;
+            [cloudSession retrieveNetworksWithCompletionBlock:^(NSArray *array, NSError *error) {
                 
-                if (array == nil || error != nil)
+                if (array == nil)
                 {
                     self.lastTestSuccessful = NO;
-                    self.lastTestFailureMessage = [NSString stringWithFormat:@"%@ - %@", [error localizedDescription], [error localizedFailureReason]];
+                    self.lastTestFailureMessage = [self failureMessageFromError:error];
                     self.callbackCompleted = YES;
                 }
                 else
                 {
-                    self.lastTestSuccessful = YES;
-                    AlfrescoLogDebug(@"testRetrieveNetworksTest");
-                    AlfrescoLogDebug(@"%@", array);
+                    AlfrescoCloudNetwork *network = cloudSession.network;
+                    XCTAssertNotNil(network, @"Expected the network property to be set");
+                    XCTAssertNotNil(cloudSession.networks, @"Expected the networks property to be set");
+                    XCTAssertTrue(cloudSession.networks.count > 0, @"Expected at least one network");
                     
-                    for (AlfrescoCloudNetwork *network in array)
-                    {
-                        AlfrescoLogDebug(@"identifier: %@", network.identifier);
-                        AlfrescoLogDebug(@"isHomeNetwork: %i", network.isHomeNetwork);
-                        AlfrescoLogDebug(@"isPaidNetwork: %i", network.isPaidNetwork);
-                        AlfrescoLogDebug(@"subscriptionLevel: %@", network.subscriptionLevel);
-                        AlfrescoLogDebug(@"createdAt: %@", network.createdAt);
-                        AlfrescoLogDebug(@"\n\n");
-                        
-                        XCTAssertTrue(network.isHomeNetwork, @"network is home network");
-                        XCTAssertNotNil(network.createdAt, @"createdAt property is set");
-                    }
+                    // check network properties
+                    XCTAssertTrue(network.isHomeNetwork, @"Expected network to be marked as the home network");
+                    XCTAssertTrue(network.isEnabled, @"Expected network to be marked as enabled");
+                    XCTAssertTrue(network.isPaidNetwork, @"Expected network to be marked as paid");
+                    XCTAssertNotNil(network.identifier, @"Expected identifier property to be set");
+                    XCTAssertNotNil(network.subscriptionLevel, @"Expected subscriptionLevel property to be set");
+                    XCTAssertNotNil(network.createdAt, @"Expected createdAt property to be set");
+                    XCTAssertTrue([network.subscriptionLevel isEqualToString:@"Enterprise"],
+                                  @"Expected subscription level to be 'Enterprise' but it was: %@", network.subscriptionLevel);
+                    
+                    self.lastTestSuccessful = YES;
                     self.callbackCompleted = YES;
                 }
+                
                 XCTAssertTrue(self.lastTestSuccessful, @"Unable to retrieve networks for the current cloud session");
             }];
+            
+            [self waitUntilCompleteWithFixedTimeInterval];
+            XCTAssertTrue(self.lastTestSuccessful, @"%@", self.lastTestFailureMessage);
         }
-        
-    }];
+    }
+    else
+    {
+        XCTFail(@"Could not run test case: %@", NSStringFromSelector(_cmd));
+    }
 }
- */
+
+- (void)testOAuthSerialization
+{
+    if (self.setUpSuccess)
+    {
+        NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+        
+        NSString *apiKey = @"ThisIsMyAPIKey-For-Alfresco-In-The-Cloud";
+        NSString *secretKey = @"ThisIsMySecretKey-For-Alfresco-In-The-Cloud";
+        NSString *redirect = @"http://www.alfresco.com";
+        
+        NSString *accessToken = @"6dbe853d-8390-4a69-b3d5-20e2125fb6e4";
+        NSString *refreshToken = @"087ed018-c29e-4b69-8c94-95805dd03a4f";
+        NSNumber *expiresIn = @3600;
+        NSString *tokenType = @"Bearer";
+        NSString *scope = @"pub_api";
+        
+        dictionary[kAlfrescoJSONAccessToken] = accessToken;
+        dictionary[kAlfrescoJSONRefreshToken] = refreshToken;
+        
+        dictionary[kAlfrescoJSONExpiresIn] = expiresIn;
+        dictionary[kAlfrescoJSONTokenType] = tokenType;
+        dictionary[kAlfrescoJSONScope] = scope;
+        
+        AlfrescoOAuthData *origOAuthData = [[AlfrescoOAuthData alloc] initWithAPIKey:apiKey secretKey:secretKey redirectURI:redirect jsonDictionary:dictionary];
+        NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:origOAuthData];
+        
+        AlfrescoOAuthData *archivedOAuthData = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
+        XCTAssertTrue([apiKey isEqualToString:archivedOAuthData.apiKey], @"apiKey should be the same but we got %@", archivedOAuthData.apiKey);
+        XCTAssertTrue([secretKey isEqualToString:archivedOAuthData.secretKey], @"secretKey should be the same but we got %@", archivedOAuthData.secretKey);
+        XCTAssertTrue([redirect isEqualToString:archivedOAuthData.redirectURI], @"redirect should be the same but we got %@", archivedOAuthData.redirectURI);
+        XCTAssertTrue([accessToken isEqualToString:archivedOAuthData.accessToken], @"accessToken should be the same but we got %@", archivedOAuthData.accessToken);
+        XCTAssertTrue([refreshToken isEqualToString:archivedOAuthData.refreshToken], @"refreshToken should be the same but we got %@", archivedOAuthData.refreshToken);
+        XCTAssertTrue([tokenType isEqualToString:archivedOAuthData.tokenType], @"tokenType should be the same but we got %@", archivedOAuthData.tokenType);
+        XCTAssertTrue([scope isEqualToString:archivedOAuthData.scope], @"scope should be the same but we got %@", archivedOAuthData.scope);
+        XCTAssertEqual(3600, [archivedOAuthData.expiresIn intValue], @"Expires in should be 3600, but instead it is %d",[archivedOAuthData.expiresIn intValue]);
+    }
+    else
+    {
+        XCTFail(@"Could not run test case: %@", NSStringFromSelector(_cmd));
+    }
+}
+
+#pragma mark - Generic Tests
 
 /*
  @Unique_TCRef 74F1
@@ -151,7 +201,6 @@
     }
 }
 
-#pragma mark - Generic Tests
 /*
  @Unique_TCRef 79S1
  @Unique_TCRef 62S1
@@ -683,48 +732,6 @@
         }
         XCTAssertTrue(self.lastTestSuccessful, @"The session does not contain valid respository information");
     }
-    else
-    {
-        XCTFail(@"Could not run test case: %@", NSStringFromSelector(_cmd));
-    }
-}
-
-- (void)testOAuthSerialization
-{
-    if (self.setUpSuccess)
-    {
-        NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-        
-        NSString *apiKey = @"ThisIsMyAPIKey-For-Alfresco-In-The-Cloud";
-        NSString *secretKey = @"ThisIsMySecretKey-For-Alfresco-In-The-Cloud";
-        NSString *redirect = @"http://www.alfresco.com";
-        
-        NSString *accessToken = @"6dbe853d-8390-4a69-b3d5-20e2125fb6e4";
-        NSString *refreshToken = @"087ed018-c29e-4b69-8c94-95805dd03a4f";
-        NSNumber *expiresIn = @3600;
-        NSString *tokenType = @"Bearer";
-        NSString *scope = @"pub_api";
-        
-        dictionary[kAlfrescoJSONAccessToken] = accessToken;
-        dictionary[kAlfrescoJSONRefreshToken] = refreshToken;
-        
-        dictionary[kAlfrescoJSONExpiresIn] = expiresIn;
-        dictionary[kAlfrescoJSONTokenType] = tokenType;
-        dictionary[kAlfrescoJSONScope] = scope;
-        
-        AlfrescoOAuthData *origOAuthData = [[AlfrescoOAuthData alloc] initWithAPIKey:apiKey secretKey:secretKey redirectURI:redirect jsonDictionary:dictionary];
-        NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:origOAuthData];
-        
-        AlfrescoOAuthData *archivedOAuthData = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
-        XCTAssertTrue([apiKey isEqualToString:archivedOAuthData.apiKey], @"apiKey should be the same but we got %@", archivedOAuthData.apiKey);
-        XCTAssertTrue([secretKey isEqualToString:archivedOAuthData.secretKey], @"secretKey should be the same but we got %@", archivedOAuthData.secretKey);
-        XCTAssertTrue([redirect isEqualToString:archivedOAuthData.redirectURI], @"redirect should be the same but we got %@", archivedOAuthData.redirectURI);
-        XCTAssertTrue([accessToken isEqualToString:archivedOAuthData.accessToken], @"accessToken should be the same but we got %@", archivedOAuthData.accessToken);
-        XCTAssertTrue([refreshToken isEqualToString:archivedOAuthData.refreshToken], @"refreshToken should be the same but we got %@", archivedOAuthData.refreshToken);
-        XCTAssertTrue([tokenType isEqualToString:archivedOAuthData.tokenType], @"tokenType should be the same but we got %@", archivedOAuthData.tokenType);
-        XCTAssertTrue([scope isEqualToString:archivedOAuthData.scope], @"scope should be the same but we got %@", archivedOAuthData.scope);
-        XCTAssertEqual(3600, [archivedOAuthData.expiresIn intValue], @"Expires in should be 3600, but instead it is %d",[archivedOAuthData.expiresIn intValue]);
-     }
     else
     {
         XCTFail(@"Could not run test case: %@", NSStringFromSelector(_cmd));


### PR DESCRIPTION
Allow the list of network a user belongs to be retrieved via a property

Also re-instated a commented out test to check the new networks property and the contents of the currently selected AlfrescoCloudNetwork object.
