### PR TITLE
#594

### DIFF
--- a/AlfrescoKit/AlfrescoKit/Supporting Files/Info.plist
+++ b/AlfrescoKit/AlfrescoKit/Supporting Files/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.alfresco.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/AlfrescoKit/AlfrescoKitBundle/Info.plist
+++ b/AlfrescoKit/AlfrescoKitBundle/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
* CFBundleExecutable was not allowed in some of the libraries.
* Also, if CODE_SIGN_RESOURCE_RULES_PATH was set you would get an corrup archive when archiving.