### PR TITLE
Branch app 2.2.1

### DIFF
--- a/AlfrescoSDK/AlfrescoSDK/Session/CloudSession/AlfrescoCloudSession.m
+++ b/AlfrescoSDK/AlfrescoSDK/Session/CloudSession/AlfrescoCloudSession.m
@@ -586,6 +586,9 @@ This authentication method authorises the user to access the home network assign
 
 - (void)setupCMISBackgroundNetworkSession:(CMISSessionParameters *)params
 {
+    /**
+     * Background session not supported whilst using a rolled-back version of ObjectiveCMIS
+     *
     BOOL useBackgroundSession = [(self.sessionData)[kAlfrescoUseBackgroundNetworkSession] boolValue];
     if (useBackgroundSession)
     {
@@ -605,6 +608,8 @@ This authentication method authorises the user to access the home network assign
         [params setObject:backgroundId forKey:kCMISSessionParameterBackgroundNetworkSessionId];
         [params setObject:containerId forKey:kCMISSessionParameterBackgroundNetworkSessionSharedContainerId];
     }
+     *
+     */
 }
 
 /**

--- a/AlfrescoSDK/AlfrescoSDK/Session/OnPremiseSession/AlfrescoRepositorySession.m
+++ b/AlfrescoSDK/AlfrescoSDK/Session/OnPremiseSession/AlfrescoRepositorySession.m
@@ -275,6 +275,9 @@
                     cmisSessionParams.authenticationProvider = (id<CMISAuthenticationProvider>)authProvider;
                 }
                 
+                /**
+                 * Background session not supported whilst using a rolled-back version of ObjectiveCMIS
+                 *
                 // setup background network session
                 BOOL useBackgroundSession = [(self.sessionData)[kAlfrescoUseBackgroundNetworkSession] boolValue];
                 if (useBackgroundSession)
@@ -295,6 +298,8 @@
                     [cmisSessionParams setObject:backgroundId forKey:kCMISSessionParameterBackgroundNetworkSessionId];
                     [cmisSessionParams setObject:containerId forKey:kCMISSessionParameterBackgroundNetworkSessionSharedContainerId];
                 }
+                 *
+                 */
                 
                 AlfrescoConnectionDiagnostic *diagnostic = [[AlfrescoConnectionDiagnostic alloc] initWithEventName:kAlfrescoConfigurationDiagnosticRepositoriesAvailableEvent];
                 [diagnostic notifyEventStart];
@@ -382,8 +387,13 @@
         cmisSessionParams.repositoryId = repoInfo.identifier;
         [cmisSessionParams setObject:NSStringFromClass([AlfrescoCMISObjectConverter class]) forKey:kCMISSessionParameterObjectConverterClassName];
         
+        /**
+         * Upload buffer size parameter not supported whilst using a rolled-back version of ObjectiveCMIS
+         *
         // IOS-458: override CMIS upload buffer chunk size form it's default value of 32768 bytes
         [cmisSessionParams setObject:@(kAlfrescoCMISUploadBufferChunkSize) forKey:kCMISSessionParameterUploadBufferChunkSize];
+         *
+         */
     
         // create CMIS session
         request.httpRequest = [CMISSession connectWithSessionParameters:cmisSessionParams

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Bindings/Browser/CMISBrowserRepositoryService.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Bindings/Browser/CMISBrowserRepositoryService.m
@@ -80,7 +80,7 @@
                                                completionBlock(nil);
                                            }
                                        } else {
-                                            completionBlock(error);
+                                           completionBlock(error);
                                        }
                                    }];
     

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Client/CMISDocument.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Client/CMISDocument.h
@@ -22,7 +22,7 @@
 @class CMISOperationContext;
 @class CMISRequest;
 
-@interface CMISDocument : CMISFileableObject
+@interface CMISDocument : CMISFileableObject <NSURLConnectionDataDelegate>
 
 @property (nonatomic, strong, readonly) NSString *contentStreamId;
 @property (nonatomic, strong, readonly) NSString *contentStreamFileName;

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Client/CMISDocument.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Client/CMISDocument.m
@@ -156,11 +156,15 @@
                       completionBlock:(void (^)(NSError *error))completionBlock
                         progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock
 {
-    return [self.binding.objectService downloadContentOfObject:self.identifier
-                                                      streamId:nil
-                                                        toFile:filePath
-                                               completionBlock:completionBlock
-                                                 progressBlock:progressBlock];
+    return [self downloadContentToFile:filePath
+                                offset:nil
+                                length:nil
+                       completionBlock:completionBlock
+                         progressBlock:^(unsigned long long bytesDownloaded, unsigned long long bytesTotal) {
+                             if (progressBlock) {
+                                 progressBlock(bytesDownloaded, bytesTotal);
+                             }
+                         }];
 }
 
 
@@ -172,7 +176,11 @@
                                         offset:nil
                                         length:nil
                                completionBlock:completionBlock
-                                 progressBlock:progressBlock];
+                                 progressBlock:^(unsigned long long bytesDownloaded, unsigned long long bytesTotal) {
+                                     if (progressBlock) {
+                                         progressBlock(bytesDownloaded, bytesTotal);
+                                     }
+                                 }];
 }
 
 - (CMISRequest*)downloadContentToFile:(NSString *)filePath

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Client/CMISSession.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Client/CMISSession.m
@@ -589,11 +589,12 @@
                             completionBlock:(void (^)(NSError *error))completionBlock
                               progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock
 {
-    return [self.binding.objectService downloadContentOfObject:objectId
-                                                      streamId:nil
-                                                        toFile:filePath
-                                               completionBlock:completionBlock
-                                                 progressBlock:progressBlock];
+    return [self downloadContentOfCMISObject:objectId
+                                      toFile:filePath
+                                      offset:nil
+                                      length:nil
+                             completionBlock:completionBlock
+                               progressBlock:progressBlock];
 }
 
 - (CMISRequest*)downloadContentOfCMISObject:(NSString *)objectId

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISAuthenticationProvider.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISAuthenticationProvider.h
@@ -51,10 +51,4 @@
  */
 - (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge;
 
-/**
- * callback when authentication challenge was received using NSURLSession
- */
-- (void)didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-          completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler;
-
 @end

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISConstants.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISConstants.h
@@ -36,7 +36,6 @@ extern NSString * const kCMISPropertyContentStreamId;
 extern NSString * const kCMISPropertyContentStreamFileName;
 extern NSString * const kCMISPropertyContentStreamLength;
 extern NSString * const kCMISPropertyContentStreamMediaType;
-extern NSString * const kCMISPropertyContentStreamHash;
 extern NSString * const kCMISPropertyObjectTypeId;
 extern NSString * const kCMISPropertyVersionSeriesId;
 extern NSString * const kCMISPropertyVersionSeriesCheckedOutBy;
@@ -140,14 +139,10 @@ extern NSString * const kCMISParameterValueReturnValueLatestMajor;
 // Common Media Types
 extern NSString * const kCMISMediaTypeOctetStream;
 
-// ContentStreamAllowed enum values
+//ContentStreamAllowed enum values
 extern NSString * const kCMISContentStreamAllowedValueRequired;
 extern NSString * const kCMISContentStreamAllowedValueAllowed;
 extern NSString * const kCMISContentStreamAllowedValueNotAllowed;
-
-// Background network default values
-extern NSString * const kCMISDefaultBackgroundNetworkSessionId;
-extern NSString * const kCMISDefaultBackgroundNetworkSessionSharedContainerId;
 
 + (NSSet *)repositoryCapabilityKeys;
 + (NSSet *)repositoryCapabilityNewTypeSettableAttributesKeys;

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISConstants.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISConstants.m
@@ -45,7 +45,6 @@ NSString * const kCMISPropertyContentStreamId = @"cmis:contentStreamId";
 NSString * const kCMISPropertyContentStreamFileName = @"cmis:contentStreamFileName";
 NSString * const kCMISPropertyContentStreamLength = @"cmis:contentStreamLength";
 NSString * const kCMISPropertyContentStreamMediaType = @"cmis:contentStreamMimeType";
-NSString * const kCMISPropertyContentStreamHash = @"cmis:contentStreamHash";
 NSString * const kCMISPropertyObjectTypeId = @"cmis:objectTypeId";
 NSString * const kCMISPropertyVersionSeriesId = @"cmis:versionSeriesId";
 NSString * const kCMISPropertyVersionSeriesCheckedOutBy = @"cmis:versionSeriesCheckedOutBy";
@@ -151,14 +150,10 @@ NSString * const kCMISParameterValueReturnValueLatestMajor = @"latestmajor";
 // Common Media Types
 NSString * const kCMISMediaTypeOctetStream = @"application/octet-stream";
 
-// ContentStreamAllowed enum values
+//ContentStreamAllowed enum values
 NSString * const kCMISContentStreamAllowedValueRequired = @"required";
 NSString * const kCMISContentStreamAllowedValueAllowed = @"allowed";
 NSString * const kCMISContentStreamAllowedValueNotAllowed = @"notallowed";
-
-// Background network default values
-NSString * const kCMISDefaultBackgroundNetworkSessionId = @"ObjectiveCMIS";
-NSString * const kCMISDefaultBackgroundNetworkSessionSharedContainerId = @"ObjectiveCMISContainer";
 
 + (NSSet *)repositoryCapabilityKeys
 {

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISErrors.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISErrors.h
@@ -106,7 +106,7 @@ extern NSString * const kCMISErrorDescriptionVersioning;
  CMIS errors are created either 
  
  - directly. This is the case when an error is captured by one of the methods/classes in the CMIS library
- - indirectly. Errors have been created by classes/methods outside the CMIS library. Example errors created through NSURLSession. In this case, the underlying error is copied into the CMIS error using the NSUnderlyingErrorKey in the userInfo Dictionary.
+ - indirectly. Errors have been created by classes/methods outside the CMIS library. Example errors created through NSURLConnection. In this case, the underlying error is copied into the CMIS error using the NSUnderlyingErrorKey in the userInfo Dictionary.
  
  */
 @interface CMISErrors : NSObject

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISNetworkProvider.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISNetworkProvider.h
@@ -124,28 +124,9 @@ useBase64Encoding:(BOOL)useBase64Encoding
 completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
  progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
 
-/**
- * Invoke method used for downloads to a file.
- * @param url the RESTful API URL to be used
- * @param httpRequestMethod
- * @param session
- * @param outputFilePath the location of the file to write the response to
- * @param bytesExpected the size of the content to be downloaded (optional)
- * @param cmisRequest a handle to the CMISRequest allowing this HTTP request to be cancelled
- * @param completionBlock returns an instance of the HTTPResponse if successful or nil otherwise
- * @param progressBlock
- */
-- (void)invoke:(NSURL *)url
-    httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-       session:(CMISBindingSession *)session
-outputFilePath:(NSString *)outputFilePath
- bytesExpected:(unsigned long long)bytesExpected
-   cmisRequest:(CMISRequest *)cmisRequest
-completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
- progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
 
 /**
- * Invoke method used for downloads to an output stream.
+ * Invoke method used for downloads,
  * @param url the RESTful API URL to be used
  * @param httpRequestMethod
  * @param session
@@ -173,7 +154,7 @@ completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))comple
  * @param outputStream the stream pointing to the destination. Must be an instance or extension of NSOutputStream
  * @param bytesExpected the size of the content to be downloaded
  * @param offset the offset of the stream or null to read the stream from the beginning
- * @param length the maximum length of the stream or null to read to the end of the stream
+ * @param legnth the maximum length of the stream or null to read to the end of the stream
  * @param completionBlock returns an instance of the HTTPResponse if successful or nil otherwise
  * @param progressBlock
  * @param requestObject a handle to the CMISRequest allowing this HTTP request to be cancelled

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISSessionParameters.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISSessionParameters.h
@@ -52,43 +52,6 @@ extern NSString * const kCMISSessionParameterTypeDefinitionCacheSize;
  */
 extern NSString * const kCMISSessionParameterSendCookies;
 
-/**
- * Key for setting whether network reachability checks should be made
- * before making a newtork call. Default is YES.
- */
-extern NSString * const kCMISSessionParameterCheckNetworkReachability;
-
-/**
- * Key for setting the timeout interval (in seconds) for a network request, default is 60.
- */
-extern NSString * const kCMISSessionParameterRequestTimeout;
-
-/**
- * Key for setting whether a background session should be used for network calls,
- * default is NO.
- * This will cause downloads and uploads to occur in a separate process.
- */
-extern NSString * const kCMISSessionParameterUseBackgroundNetworkSession;
-
-/**
- * Key for setting the identifier to use for the background session, ignored unless
- * kCMISSessionParameterUseBackgroundNetworkSession is set to YES.
- * If not set, background sessions will use an identifier of "ObjectiveCMIS".
- */
-extern NSString * const kCMISSessionParameterBackgroundNetworkSessionId;
-
-/**
- * Key for setting the shared container identifier used by the background network session.
- * If not set, an identifier of "ObjectiveCMISContainer" will be used.
- */
-extern NSString * const kCMISSessionParameterBackgroundNetworkSessionSharedContainerId;
-
-/**
- * Key for overriding the default upload buffer chunk size during the Base64 encoding phase.
- * If not specified, the default chunk size of 32768 bytes will be used.
- */
-extern NSString * const kCMISSessionParameterUploadBufferChunkSize;
-
 
 @interface CMISSessionParameters : NSObject
 

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISSessionParameters.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISSessionParameters.m
@@ -25,14 +25,6 @@ NSString * const kCMISSessionParameterLinkCacheSize = @"session_param_cache_size
 NSString * const kCMISSessionParameterTypeDefinitionCacheSize = @"session_param_cache_size_type_definition";
 NSString * const kCMISSessionParameterSendCookies = @"session_param_send_cookies";
 
-NSString * const kCMISSessionParameterCheckNetworkReachability = @"session_param_check_network_reachability";
-NSString * const kCMISSessionParameterRequestTimeout = @"session_param_request_timeout";
-NSString * const kCMISSessionParameterUseBackgroundNetworkSession = @"session_param_use_background_session";
-NSString * const kCMISSessionParameterBackgroundNetworkSessionId = @"session_param_background_session_id";
-NSString * const kCMISSessionParameterBackgroundNetworkSessionSharedContainerId = @"session_param_background_session_shared_container_id";
-
-NSString * const kCMISSessionParameterUploadBufferChunkSize = @"session_param_upload_chunk_size";
-
 @interface CMISSessionParameters ()
 @property (nonatomic, assign, readwrite) CMISBindingType bindingType;
 @property (nonatomic, strong, readwrite) NSMutableDictionary *sessionData;

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISStandardAuthenticationProvider.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISStandardAuthenticationProvider.m
@@ -62,10 +62,6 @@
     return [NSDictionary dictionary];
 }
 
-- (void)updateWithHttpURLResponse:(NSHTTPURLResponse*)httpUrlResponse
-{
-    // nothing to do in the default implementation
-}
 
 - (BOOL)canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
 {
@@ -112,29 +108,11 @@
     }
 }
 
-- (void)didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-          completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+
+- (void)updateWithHttpURLResponse:(NSHTTPURLResponse*)httpUrlResponse
 {
-    if (challenge.previousFailureCount == 0) {
-        if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate] &&
-            self.credential.identity) {
-            CMISLogDebug(@"Authenticating with client certificate");
-            completionHandler(NSURLSessionAuthChallengeUseCredential, self.credential);
-        } else if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] &&
-                   self.credential.user && self.credential.hasPassword) {
-            CMISLogDebug(@"Authenticating with username and password");
-            completionHandler(NSURLSessionAuthChallengeUseCredential, self.credential);
-        } else if (challenge.proposedCredential) {
-            CMISLogDebug(@"Authenticating with proposed credential");
-            completionHandler(NSURLSessionAuthChallengeUseCredential, challenge.proposedCredential);
-        } else {
-            CMISLogDebug(@"Authenticating without credential");
-            completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-        }
-    } else {
-        CMISLogDebug(@"Authentication failed, cancelling logon");
-        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
-    }
+    // nothing to do in the default implementation
 }
+
 
 @end

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISStandardUntrustedSSLAuthenticationProvider.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Common/CMISStandardUntrustedSSLAuthenticationProvider.m
@@ -18,7 +18,6 @@
  */
 
 #import "CMISStandardUntrustedSSLAuthenticationProvider.h"
-#import "CMISLog.h"
 
 @implementation CMISStandardUntrustedSSLAuthenticationProvider
 
@@ -41,23 +40,9 @@
     if ((challenge.previousFailureCount == 0) &&
         ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]))
     {
-        CMISLogWarning(@"Allowing self-signed certificate");
         [challenge.sender useCredential:[NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust] forAuthenticationChallenge:challenge];
     } else {
         [super didReceiveAuthenticationChallenge:challenge];
-    }
-}
-
-- (void)didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-          completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
-{
-    if ((challenge.previousFailureCount == 0) &&
-        ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]))
-    {
-        CMISLogWarning(@"Allowing self-signed certificate");
-        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-    } else {
-        [super didReceiveChallenge:challenge completionHandler:completionHandler];
     }
 }
 

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpDownloadRequest.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpDownloadRequest.h
@@ -19,11 +19,7 @@
 
 #import "CMISHttpRequest.h"
 
-@interface CMISHttpDownloadRequest : CMISHttpRequest <NSURLSessionDownloadDelegate>
-
-// The file path to write the response body to.
-// This will force the use of a download task internally.
-@property (nonatomic, strong) NSString *outputFilePath;
+@interface CMISHttpDownloadRequest : CMISHttpRequest 
 
 // the outputStream should be unopened but if it is already open it will not be reset but used as is;
 // it is closed on completion; if no outputStream is provided, download goes to httpResponse.data
@@ -37,36 +33,25 @@
 /** starts a URL request for download. Data are written to the provided output stream
  * completionBlock returns a CMISHttpResponse object or nil if unsuccessful
  */
-+ (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-      outputStream:(NSOutputStream*)outputStream
-     bytesExpected:(unsigned long long)bytesExpected
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
-     progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
++ (id)startRequest:(NSMutableURLRequest*)urlRequest
+                              httpMethod:(CMISHttpRequestMethod)httpRequestMethod
+                            outputStream:(NSOutputStream*)outputStream
+                           bytesExpected:(unsigned long long)bytesExpected
+                  authenticationProvider:(id<CMISAuthenticationProvider>) authenticationProvider
+                         completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
+                           progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
 
 /** starts a URL request for download with a given offset and or length. Data are written to the provided output stream
  * completionBlock returns a CMISHttpResponse object or nil if unsuccessful
  */
 + (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-      outputStream:(NSOutputStream*)outputStream
-     bytesExpected:(unsigned long long)bytesExpected
-            offset:(NSDecimalNumber*)offset
-            length:(NSDecimalNumber*)length
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
-     progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
-
-/** starts a URL request for download. Data is written to the provided file path.
- * completionBlock returns a CMISHttpResponse object or nil if unsuccessful
- */
-+ (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-    outputFilePath:(NSString *)outputFilePath
-     bytesExpected:(unsigned long long)bytesExpected
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
-     progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
+                              httpMethod:(CMISHttpRequestMethod)httpRequestMethod
+                            outputStream:(NSOutputStream*)outputStream
+                           bytesExpected:(unsigned long long)bytesExpected
+                                  offset:(NSDecimalNumber*)offset
+                                  length:(NSDecimalNumber*)length
+                  authenticationProvider:(id<CMISAuthenticationProvider>) authenticationProvider
+                         completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
+                           progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
 
 @end

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpDownloadRequest.m
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpDownloadRequest.m
@@ -26,7 +26,6 @@
 @property (nonatomic, copy) void (^progressBlock)(unsigned long long bytesDownloaded, unsigned long long bytesTotal);
 @property (nonatomic, assign) unsigned long long bytesDownloaded;
 @property (nonatomic, assign) BOOL cancelled;
-@property (nonatomic, strong) NSError *fileCopyError;
 
 - (id)initWithHttpMethod:(CMISHttpRequestMethod)httpRequestMethod
          completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
@@ -41,37 +40,35 @@
         httpMethod:(CMISHttpRequestMethod)httpRequestMethod
       outputStream:(NSOutputStream*)outputStream
      bytesExpected:(unsigned long long)bytesExpected
-           session:(CMISBindingSession *)session
+authenticationProvider:(id<CMISAuthenticationProvider>) authenticationProvider
    completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
      progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock
 {
     return [CMISHttpDownloadRequest startRequest:urlRequest
-                                      httpMethod:httpRequestMethod
-                                    outputStream:outputStream
-                                   bytesExpected:bytesExpected
-                                          offset:nil
-                                          length:nil
-                                         session:session
-                                 completionBlock:completionBlock
-                                   progressBlock:progressBlock];
+                               httpMethod:httpRequestMethod
+                             outputStream:outputStream
+                            bytesExpected:bytesExpected
+                   authenticationProvider:authenticationProvider
+                          completionBlock:completionBlock
+                            progressBlock:progressBlock];
 }
 
 + (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-      outputStream:(NSOutputStream*)outputStream
-     bytesExpected:(unsigned long long)bytesExpected
-            offset:(NSDecimalNumber*)offset
-            length:(NSDecimalNumber*)length
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
-     progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock
+                              httpMethod:(CMISHttpRequestMethod)httpRequestMethod
+                            outputStream:(NSOutputStream*)outputStream
+                           bytesExpected:(unsigned long long)bytesExpected
+                                  offset:(NSDecimalNumber*)offset
+                                  length:(NSDecimalNumber*)length
+                  authenticationProvider:(id<CMISAuthenticationProvider>) authenticationProvider
+                         completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
+                           progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock
 {
     CMISHttpDownloadRequest *httpRequest = [[self alloc] initWithHttpMethod:httpRequestMethod
                                                             completionBlock:completionBlock
                                                               progressBlock:progressBlock];
     httpRequest.outputStream = outputStream;
     httpRequest.bytesExpected = bytesExpected;
-    httpRequest.session = session;
+    httpRequest.authenticationProvider = authenticationProvider;
     
     //range
     if ((offset != nil) || (length != nil)) {
@@ -95,27 +92,6 @@
     return httpRequest;
 }
 
-+ (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-    outputFilePath:(NSString *)outputFilePath
-     bytesExpected:(unsigned long long)bytesExpected
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
-     progressBlock:(void (^)(unsigned long long bytesDownloaded, unsigned long long bytesTotal))progressBlock;
-{
-    CMISHttpDownloadRequest *httpRequest = [[self alloc] initWithHttpMethod:httpRequestMethod
-                                                            completionBlock:completionBlock
-                                                              progressBlock:progressBlock];
-    httpRequest.outputFilePath = outputFilePath;
-    httpRequest.bytesExpected = bytesExpected;
-    httpRequest.session = session;
-    
-    if (![httpRequest startRequest:urlRequest]) {
-        httpRequest = nil;
-    };
-    
-    return httpRequest;
-}
 
 - (id)initWithHttpMethod:(CMISHttpRequestMethod)httpRequestMethod
          completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
@@ -129,50 +105,54 @@
     return self;
 }
 
-- (NSURLSessionTask *)taskForRequest:(NSURLRequest *)request
-{
-    if (self.outputFilePath) {
-        return [self.urlSession downloadTaskWithRequest:request];
-    } else {
-        return [super taskForRequest:request];
-    }
-}
-
-#pragma mark CMISCancellableRequest method
 
 - (void)cancel
 {
-    [super cancel];
-    
-    // clean up
     [self.outputStream close];
+    
     self.progressBlock = nil;
+    
+    [super cancel];
 }
 
-#pragma mark Session delegate methods
 
-- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
 {
-    // clean up
-    [self.outputStream close];
-    self.progressBlock = nil;
+    [super connection:connection didReceiveResponse:response];
     
-    if (self.outputFilePath) {
-        // download tasks don't return the response via delegate methods so get it from the task
-        self.response = (NSHTTPURLResponse *)task.response;
-        
-        if (self.fileCopyError) {
-            error = self.fileCopyError;
+    // update statistics
+    if (self.bytesExpected == 0 && response.expectedContentLength != NSURLResponseUnknownLength) {
+        self.bytesExpected = response.expectedContentLength;
+    }
+    self.bytesDownloaded = 0;
+
+    // set up output stream if available
+    if (self.outputStream) { // otherwise store data in memory in self.data
+        // create file for downloaded content
+        BOOL isStreamReady = self.outputStream.streamStatus == NSStreamStatusOpen;
+        if (!isStreamReady) {
+            [self.outputStream open];
+            isStreamReady = self.outputStream.streamStatus == NSStreamStatusOpen;
+        }
+    
+        if (!isStreamReady) {
+            [connection cancel];
+            
+            if (self.completionBlock)
+            {
+                NSError *cmisError = [CMISErrors createCMISErrorWithCode:kCMISErrorCodeStorage
+                                                     detailedDescription:@"Could not open output stream"];
+                self.completionBlock(nil, cmisError);
+            }
         }
     }
-    
-    [super URLSession:session task:task didCompleteWithError:error];
 }
 
-- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
 {
     if (self.outputStream == nil) { // if there is no outputStream then store data in memory in self.data
-        [super URLSession:session dataTask:dataTask didReceiveData:data];
+        [super connection:connection didReceiveData:data];
     } else {
         const uint8_t *bytes = data.bytes;
         NSUInteger length = data.length;
@@ -180,8 +160,8 @@
         do {
             NSUInteger written = [self.outputStream write:&bytes[offset] maxLength:length - offset];
             if (written <= 0) {
-                CMISLogError(@"Error while writing downloaded data to stream");
-                [session invalidateAndCancel];
+                CMISLogError(@"Error while writing downloaded data to file");
+                [connection cancel];
                 return;
             } else {
                 offset += written;
@@ -191,93 +171,31 @@
     
     // update statistics
     self.bytesDownloaded += data.length;
-    
-    // pass progress to progressBlock, on the original thread
-    if (self.originalThread) {
-        [self performSelector:@selector(executeProgressBlock:) onThread:self.originalThread withObject:@[@(self.bytesDownloaded), @(self.bytesExpected)] waitUntilDone:NO];
-    }
-}
-
-- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
-{
-    // update statistics
-    if (self.bytesExpected == 0 && self.sessionTask.countOfBytesExpectedToReceive != NSURLSessionTransferSizeUnknown) {
-        self.bytesExpected = self.sessionTask.countOfBytesExpectedToReceive;
-    }
-    
-    self.bytesDownloaded = 0;
-    
-    // set up output stream if available
-    if (self.outputStream) { // otherwise store data in memory in self.data
-        // create file for downloaded content
-        BOOL isStreamReady = self.outputStream.streamStatus == NSStreamStatusOpen;
-        if (!isStreamReady) {
-            [self.outputStream open];
-            isStreamReady = self.outputStream.streamStatus == NSStreamStatusOpen;
-        }
-        
-        if (isStreamReady) {
-            [super URLSession:session dataTask:dataTask didReceiveResponse:response completionHandler:completionHandler];
-        } else {
-            [session invalidateAndCancel];
-            
-            if (self.completionBlock)
-            {
-                NSError *cmisError = [CMISErrors createCMISErrorWithCode:kCMISErrorCodeStorage
-                                                     detailedDescription:@"Could not open output stream"];
-                
-                // call the completion block on the original thread
-                if (self.originalThread) {
-                    [self performSelector:@selector(executeCompletionBlockError:) onThread:self.originalThread withObject:cmisError waitUntilDone:NO];
-                }
-            }
-        }
-    }
-}
-
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didResumeAtOffset:(int64_t)fileOffset expectedTotalBytes:(int64_t)expectedTotalBytes
-{
-    // TODO: Add support for resuming download tasks
-}
-
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
-{
-    // create URL representation of destination
-    NSURL *destinationURL = [NSURL fileURLWithPath:self.outputFilePath];
-
-    // remove the current file, if it exists
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    [fileManager removeItemAtURL:destinationURL error:nil];
-    
-    // copy the temporary file to the requested file path
-    if ([fileManager copyItemAtURL:location toURL:destinationURL error:nil]) {
-        CMISLogDebug(@"Copied downloaded file from %@ to %@", location, self.outputFilePath);
-    } else {
-        self.fileCopyError = [CMISErrors createCMISErrorWithCode:kCMISErrorCodeStorage
-                                             detailedDescription:[NSString stringWithFormat:@"Could not copy temporary file to %@", self.outputFilePath]];
-    }
-}
-
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
-{
-    // pass progress to progressBlock, on the main thread
+    // pass progress to progressBlock
     if (self.progressBlock) {
-        unsigned long long totalBytesExpected = totalBytesExpectedToWrite;
-        
-        if (totalBytesExpected == NSURLSessionTransferSizeUnknown && self.bytesExpected != 0) {
-            totalBytesExpected = self.bytesExpected;
-        }
-        // pass progress to progressBlock, on the original thread
-        if (self.originalThread) {
-            [self performSelector:@selector(executeProgressBlock:) onThread:self.originalThread withObject:@[@(totalBytesWritten), @(totalBytesExpected)] waitUntilDone:NO];
-        }
+        self.progressBlock(self.bytesDownloaded, self.bytesExpected);
     }
+    
 }
 
-- (void)executeProgressBlock:(NSArray*)valueArray {
-    if (self.progressBlock) {
-        self.progressBlock([valueArray[0] unsignedLongLongValue], [valueArray[1] unsignedLongLongValue]);
-    }
+
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
+{
+    [self.outputStream close];
+
+    self.progressBlock = nil;
+
+    [super connection:connection didFailWithError:error];
+}
+
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection
+{
+    [self.outputStream close];
+
+    self.progressBlock = nil;
+
+    [super connectionDidFinishLoading:connection];
 }
 
 @end

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpRequest.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpRequest.h
@@ -23,18 +23,16 @@
 #import "CMISRequest.h"
 @class CMISAuthenticationProvider;
 
-@interface CMISHttpRequest : NSObject <CMISCancellableRequest, NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
+@interface CMISHttpRequest : NSObject <NSURLConnectionDelegate, NSURLConnectionDataDelegate, CMISCancellableRequest>
 
 @property (nonatomic, assign) CMISHttpRequestMethod requestMethod;
-@property (nonatomic, strong) NSURLSession *urlSession;
-@property (nonatomic, strong) NSURLSessionTask *sessionTask;
+@property (nonatomic, strong) NSURLConnection *connection;
 @property (nonatomic, strong) NSData *requestBody;
 @property (nonatomic, strong) NSMutableData *responseBody;
 @property (nonatomic, strong) NSDictionary *additionalHeaders;
 @property (nonatomic, strong) NSHTTPURLResponse *response;
-@property (nonatomic, strong) CMISBindingSession *session;
+@property (nonatomic, strong) id<CMISAuthenticationProvider> authenticationProvider;
 @property (nonatomic, copy) void (^completionBlock)(CMISHttpResponse *httpResponse, NSError *error);
-@property (nonatomic, weak) NSThread *originalThread;
 
 /**
  * starts a URL request for given HTTP method 
@@ -44,11 +42,11 @@
  * completionBlock returns a CMISHTTPResponse object or nil if unsuccessful
  */
 + (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-       requestBody:(NSData*)requestBody
-           headers:(NSDictionary*)additionalHeaders
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock;
+                      httpMethod:(CMISHttpRequestMethod)httpRequestMethod
+                     requestBody:(NSData*)requestBody
+                         headers:(NSDictionary*)additionalHeaders
+          authenticationProvider:(id<CMISAuthenticationProvider>)authenticationProvider
+                 completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock;
 
 /**
  * initialises with a specified HTTP method
@@ -58,14 +56,5 @@
 
 /// starts the URL request
 - (BOOL)startRequest:(NSMutableURLRequest*)urlRequest;
-
-/// Creates an appropriate task for the given request object.
-- (NSURLSessionTask *)taskForRequest:(NSURLRequest *)request;
-
-/// Call completion block with response returned from server
-- (void)executeCompletionBlockResponse:(CMISHttpResponse*)response;
-
-/// Call completion block with error returned from server
-- (void)executeCompletionBlockError:(NSError*)error;
 
 @end

--- a/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpUploadRequest.h
+++ b/AlfrescoSDK/CMIS/ObjectiveCMIS/Utils/CMISHttpUploadRequest.h
@@ -30,13 +30,13 @@
  * completionBlock returns CMISHttpResponse instance or nil if unsuccessful
  */
 + (id)startRequest:(NSMutableURLRequest *)urlRequest
-        httpMethod:(CMISHttpRequestMethod)httpRequestMethod
-       inputStream:(NSInputStream*)inputStream
-           headers:(NSDictionary*)additionalHeaders
-     bytesExpected:(unsigned long long)bytesExpected
-           session:(CMISBindingSession *)session
-   completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
-     progressBlock:(void (^)(unsigned long long bytesUploaded, unsigned long long bytesTotal))progressBlock;
+                            httpMethod:(CMISHttpRequestMethod)httpRequestMethod
+                           inputStream:(NSInputStream*)inputStream
+                               headers:(NSDictionary*)additionalHeaders
+                         bytesExpected:(unsigned long long)bytesExpected
+                authenticationProvider:(id<CMISAuthenticationProvider>) authenticationProvider
+                       completionBlock:(void (^)(CMISHttpResponse *httpResponse, NSError *error))completionBlock
+                         progressBlock:(void (^)(unsigned long long bytesUploaded, unsigned long long bytesTotal))progressBlock;
 
 /**
  * starts a URL request with a provided input stream. The input stream has to point to the raw NON-encoded data set. This method will first write the 
@@ -47,7 +47,7 @@
        inputStream:(NSInputStream*)sourceInputStream
            headers:(NSDictionary*)additionalHeaders
      bytesExpected:(unsigned long long)bytesExpected
-           session:(CMISBindingSession *)session
+authenticationProvider:(id<CMISAuthenticationProvider>) authenticationProvider
          startData:(NSData *)startData
            endData:(NSData *)endData
  useBase64Encoding:(BOOL)useBase64Encoding


### PR DESCRIPTION
IOS-480 workaround
Reverts changes in ObjectiveCMIS that migrated the networking layer to use NSURLSession in place of NSURLConnection.
These changes have the undesirable effect of stalling NSOperation-based concurrent network requests in the app layer, possibly due to multiple instances of NSURLSession being allocated.
The changes also cause problems when attempting to use the SDK with "background networking support" enabled.